### PR TITLE
feat: add rate limiting and basic security middleware for snippets API

### DIFF
--- a/app/api/snippets/route.ts
+++ b/app/api/snippets/route.ts
@@ -1,5 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getSnippets, createSnippet } from '@/lib/db';
+import { rateLimit } from '@/lib/rateLimiter';
+import { validateRequestSize } from '@/lib/security';
+
+const RATE_LIMIT_WINDOW_MS = 60 * 1000;
+const RATE_LIMIT_MAX_REQUESTS = 20;
 
 export async function GET() {
   try {
@@ -16,12 +21,55 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   try {
+    const ip =
+      req.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ||
+      req.headers.get('x-real-ip') ||
+      'unknown';
+
+    const limit = rateLimit(`snippet-create:${ip}`, {
+      windowMs: RATE_LIMIT_WINDOW_MS,
+      max: RATE_LIMIT_MAX_REQUESTS,
+    });
+
+    if (!limit.allowed) {
+      console.warn('[security] Snippet creation rate limit exceeded:', { ip });
+
+      return NextResponse.json(
+        {
+          error: 'Rate limit exceeded',
+          limit: RATE_LIMIT_MAX_REQUESTS,
+          window: `${RATE_LIMIT_WINDOW_MS / 1000}s`,
+        },
+        { status: 429 }
+      );
+    }
+
     const body = await req.json();
+
+    if (!validateRequestSize(body)) {
+      console.warn('[security] Snippet creation request too large:', { ip });
+
+      return NextResponse.json(
+        { error: 'Request body too large' },
+        { status: 413 }
+      );
+    }
+
     const { title, description, code, language, tags } = body;
 
-    if (!title || !description || !code || !language || !tags || tags.length === 0) {
+    if (
+      !title ||
+      !description ||
+      !code ||
+      !language ||
+      !Array.isArray(tags) ||
+      tags.length === 0
+    ) {
       return NextResponse.json(
-        { error: 'Missing required fields: title, description, code, language, tags' },
+        {
+          error:
+            'Missing required fields: title, description, code, language, tags',
+        },
         { status: 400 }
       );
     }

--- a/lib/rateLimiter.ts
+++ b/lib/rateLimiter.ts
@@ -1,0 +1,37 @@
+type RateLimitOptions = {
+  windowMs: number;
+  max: number;
+};
+
+type RateLimitEntry = {
+  count: number;
+  resetAt: number;
+};
+
+const store = new Map<string, RateLimitEntry>();
+
+export function rateLimit(key: string, options: RateLimitOptions) {
+  const now = Date.now();
+  const entry = store.get(key);
+
+  if (!entry || now > entry.resetAt) {
+    store.set(key, {
+      count: 1,
+      resetAt: now + options.windowMs,
+    });
+
+    return { allowed: true };
+  }
+
+  if (entry.count >= options.max) {
+    return {
+      allowed: false,
+      error: "Rate limit exceeded",
+      limit: options.max,
+      window: `${options.windowMs / 1000}s`,
+    };
+  }
+
+  entry.count += 1;
+  return { allowed: true };
+}

--- a/lib/security.ts
+++ b/lib/security.ts
@@ -1,0 +1,3 @@
+export function validateRequestSize(body: unknown, maxBytes = 10 * 1024) {
+  return JSON.stringify(body).length <= maxBytes;
+}


### PR DESCRIPTION
## 🚀 Feature: Rate Limiting & Basic Security Middleware

### 📌 Overview
This PR implements rate limiting and basic security checks for snippet creation APIs to prevent abuse and ensure backend stability.

---

### ✅ Changes Implemented

- 🔒 **Rate Limiting**
  - Limits snippet creation requests to **20 requests per minute per IP**
  - Returns `429 Too Many Requests` when limit is exceeded

- 🛡 **Basic Security Checks**
  - Validates request body size (max 10KB)
  - Ensures required fields are present

- ⚙️ **Configurable**
  - Rate limit window and request count are configurable

- 🔁 **Auto Reset**
  - Limits reset automatically after defined time window

- 📊 **Logging**
  - Logs rate limit violations and invalid requests for debugging

---

### 📦 Files Added/Updated

- `lib/rateLimiter.ts` → In-memory rate limiting utility
- `lib/security.ts` → Basic request validation
- `app/api/snippets/route.ts` → Integrated middleware into POST endpoint

---

### 🧪 Testing

- Verified successful snippet creation under limit
- Verified `429` response after exceeding request limit
- Verified `400` for invalid request body

---

### ⚠️ Note

This implementation uses an **in-memory store** for rate limiting.  
For production scalability, this can be replaced with a **Redis-based solution**.

---

### 🎯 Issue

Closes #44