### PR TITLE
fix: resolve Save/Update Snippet button not submitting (#21)

### DIFF
--- a/components/SnippetForm.tsx
+++ b/components/SnippetForm.tsx
@@ -15,8 +15,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { LANGUAGES } from "@/lib/languages";
-import { fetchSnippets } from "@/lib/utils";
-import React, { SetStateAction } from "react";
+import React, { useEffect, useState } from "react";
 import { SnippetFormValues } from "@/types/type";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { snippetSchema } from "@/validiation/snippet-form-validiation";
@@ -24,18 +23,26 @@ import { toast } from "sonner";
 
 interface SnippetFormProps {
   editingId: string | null;
-  submitting: boolean;
-  setSubmitting: React.Dispatch<SetStateAction<boolean>>;
+  initialValues?: Partial<SnippetFormValues>;
   closeForm: () => void;
+  onSuccess: () => Promise<void>;
 }
 
 export default function SnippetForm({
   editingId,
-  setSubmitting,
+  initialValues,
   closeForm,
-  submitting,
+  onSuccess,
 }: SnippetFormProps) {
-  const form = useForm<SnippetFormValues>({
+  const [submitting, setSubmitting] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    control,
+    reset,
+    formState: { errors },
+  } = useForm<SnippetFormValues>({
     resolver: zodResolver(snippetSchema),
     defaultValues: {
       title: "",
@@ -46,22 +53,17 @@ export default function SnippetForm({
     },
   });
 
-  const {
-    register,
-    handleSubmit,
-    control,
-    formState: { errors },
-  } = form;
+  useEffect(() => {
+    reset({
+      title: initialValues?.title ?? "",
+      description: initialValues?.description ?? "",
+      code: initialValues?.code ?? "",
+      language: initialValues?.language ?? "javascript",
+      tags: initialValues?.tags ?? "",
+    });
+  }, [initialValues, reset]);
 
   const onSubmit = async (data: SnippetFormValues) => {
-    // Mock isConnected state - replace with real state later
-    const isConnected = false;
-
-    if (!isConnected) {
-      toast.error("Please connect your wallet before submitting.");
-      return;
-    }
-
     try {
       setSubmitting(true);
       const payload = {
@@ -88,10 +90,11 @@ export default function SnippetForm({
 
       if (!res.ok) throw new Error("Failed to save snippet");
 
-      await fetchSnippets();
+      await onSuccess();
       closeForm();
     } catch (error) {
       console.error("Error saving snippet:", error);
+      toast.error("Failed to save snippet. Please try again.");
     } finally {
       setSubmitting(false);
     }


### PR DESCRIPTION
## Summary

- **Root cause 1**: `SnippetForm.tsx` had `const isConnected = false` hard-coded, which triggered a wallet toast error and returned early on *every* submit — no API call was ever made
- **Root cause 2**: `fetchSnippets` imported from `lib/utils.ts` had `setSnippets(...)` commented out, so calling it after a save fetched data but threw it away — the snippet list never refreshed
- **Root cause 3**: `SnippetForm` had no `initialValues` prop, so clicking Edit opened a blank form instead of pre-filling the snippet's data
- **Root cause 4**: `submitting` state was split between parent and child with no wiring in the page, so the loading spinner never appeared

## Changes

- Removed the `isConnected` guard entirely (mock that blocked all submissions)
- Moved `submitting` state inside `SnippetForm` so it manages its own loading lifecycle
- Added `initialValues?: Partial<SnippetFormValues>` prop; form resets via `useEffect` when editing a snippet
- Replaced the broken `fetchSnippets` import with an `onSuccess: () => Promise<void>` callback prop so the parent controls list refresh
- Added a user-facing `toast.error(...)` on API failure instead of a silent `console.error`
- Removed the duplicated inline form in `app/snippets/page.tsx` (~220 lines) and replaced it with `<SnippetForm />`, passing `fetchSnippets` as `onSuccess`

## Test plan

- [ ] Click **Add Snippet**, fill the form, click **Save Snippet** — button shows spinner while saving, list refreshes, form closes
- [ ] Click **Edit** on an existing snippet — form opens pre-filled with existing values
- [ ] Click **Update Snippet** — saves correctly, list refreshes, form closes
- [ ] Simulate an API failure (e.g. disconnect DB) — error toast appears, form stays open
- [ ] Submit with missing required fields — Zod validation errors appear inline

Closes #21
