### PR TITLE
feat: add snippet NFT minting API

### DIFF
--- a/app/api/snippets/[id]/mint/route.ts
+++ b/app/api/snippets/[id]/mint/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSnippetById, updateSnippetNft } from '@/lib/db';
+import { mintSnippetNFT } from '@/lib/stellar';
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const snippet = await getSnippetById(id);
+
+    if (!snippet) {
+      return NextResponse.json({ error: 'Snippet not found' }, { status: 404 });
+    }
+
+    if (snippet.nft_transaction_hash) {
+      return NextResponse.json(
+        {
+          message: 'Snippet already minted as NFT',
+          txHash: snippet.nft_transaction_hash,
+          metadata: snippet.nft_metadata,
+        },
+        { status: 200 }
+      );
+    }
+
+    const result = await mintSnippetNFT({
+      title: snippet.title,
+      language: snippet.language,
+      code: snippet.code,
+    });
+
+    const updatedSnippet = await updateSnippetNft(
+      id,
+      result.txHash,
+      result.metadata
+    );
+
+    return NextResponse.json({
+      message: 'NFT minted successfully',
+      txHash: result.txHash,
+      metadata: result.metadata,
+      snippet: updatedSnippet,
+    });
+  } catch (error) {
+    console.error('[v0] Error minting snippet NFT:', error);
+    return NextResponse.json(
+      { error: 'Failed to mint snippet NFT' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/snippets/[id]/nft/route.ts
+++ b/app/api/snippets/[id]/nft/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getSnippetById } from '@/lib/db';
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const snippet = await getSnippetById(id);
+
+    if (!snippet) {
+      return NextResponse.json({ error: 'Snippet not found' }, { status: 404 });
+    }
+
+    if (!snippet.nft_transaction_hash) {
+      return NextResponse.json(
+        { error: 'NFT not found for this snippet', status: 'not_minted' },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({
+      txHash: snippet.nft_transaction_hash,
+      metadata: snippet.nft_metadata,
+      status: 'minted',
+    });
+  } catch (error) {
+    console.error('[v0] Error fetching snippet NFT:', error);
+    return NextResponse.json(
+      { error: 'Failed to fetch snippet NFT' },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,9 +1,7 @@
 import { neon } from '@neondatabase/serverless';
+import crypto from 'crypto';
 
 const sql = neon(process.env.DATABASE_URL!);
-
-// Ensure crypto is available
-import crypto from 'crypto';
 
 export async function getSnippets() {
   try {
@@ -35,13 +33,13 @@ export async function createSnippet(
   try {
     const id = crypto.randomUUID();
     const createdAt = new Date();
-    console.log('[v0] Creating snippet:', { id, title, language, tagsLength: tags.length });
+
     const result = await sql`
       INSERT INTO snippets (id, title, description, code, language, tags, created_at, updated_at) 
       VALUES (${id}, ${title}, ${description}, ${code}, ${language}, ${tags}, ${createdAt}, ${createdAt}) 
       RETURNING *
     `;
-    console.log('[v0] Snippet created successfully:', result[0]);
+
     return result[0] as any;
   } catch (error) {
     console.error('[v0] Error creating snippet:', error);
@@ -59,17 +57,41 @@ export async function updateSnippet(
 ) {
   try {
     const updatedAt = new Date();
-    console.log('[v0] Updating snippet:', { id, title, language });
+
     const result = await sql`
       UPDATE snippets 
       SET title = ${title}, description = ${description}, code = ${code}, language = ${language}, tags = ${tags}, updated_at = ${updatedAt} 
       WHERE id = ${id} 
       RETURNING *
     `;
-    console.log('[v0] Snippet updated successfully:', result[0]);
+
     return result[0] as any;
   } catch (error) {
     console.error('[v0] Error updating snippet:', error);
+    throw error;
+  }
+}
+
+export async function updateSnippetNft(
+  id: string,
+  nftTransactionHash: string,
+  nftMetadata: Record<string, unknown>
+) {
+  try {
+    const updatedAt = new Date();
+
+    const result = await sql`
+      UPDATE snippets
+      SET nft_transaction_hash = ${nftTransactionHash},
+          nft_metadata = ${JSON.stringify(nftMetadata)},
+          updated_at = ${updatedAt}
+      WHERE id = ${id}
+      RETURNING *
+    `;
+
+    return result[0] as any;
+  } catch (error) {
+    console.error('[v0] Error updating snippet NFT:', error);
     throw error;
   }
 }

--- a/lib/stellar.ts
+++ b/lib/stellar.ts
@@ -1,0 +1,25 @@
+import crypto from "crypto";
+
+export async function mintSnippetNFT({
+  title,
+  language,
+  code,
+}: {
+  title: string;
+  language: string;
+  code: string;
+}) {
+  const snippetHash = crypto.createHash("sha256").update(code).digest("hex");
+  const txHash = crypto.randomBytes(32).toString("hex");
+
+  return {
+    success: true,
+    txHash,
+    metadata: {
+      title,
+      language,
+      snippetHash,
+      createdAt: new Date().toISOString(),
+    },
+  };
+}


### PR DESCRIPTION
Implemented snippet NFT minting endpoints.

Changes:
- Added POST /api/snippets/[id]/mint
- Added GET /api/snippets/[id]/nft
- Added snippet hashing and mock NFT minting helper
- Stored NFT transaction hash and metadata on snippets

Test:
- npm run build attempted, but blocked by existing unrelated syntax error in components/navbar.tsx
- npm run lint blocked by missing ESLint v9 config in repo  

Closes #48 