### PR TITLE
feat: add Connect Wallet button to landing page hero

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,7 +4,6 @@ import { Geist, Geist_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
 import ClientWalletProvider from "@/components/ClientWalletProvider";
 import "./globals.css";
-import { Navbar } from "@/components/navbar";
 
 const geistSans = Geist({
 	subsets: ["latin"],
@@ -38,15 +37,10 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
 	return (
 		<html lang='en' suppressHydrationWarning>
-			<body className='font-sans antialiased'>
-
+			<body className={`${geistSans.variable} ${geistMono.variable} font-sans antialiased`}>
 				<ClientWalletProvider>
-					<main>{children}</main>
+					{children}
 				</ClientWalletProvider>
-
-				<Navbar />
-				<main>{children}</main>
-
 				<Analytics />
 			</body>
 		</html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,6 +16,7 @@ import {
   Sparkles,
 } from "lucide-react";
 import { Navbar } from "@/components/navbar";
+import { WalletButton } from "@/components/WalletConnect";
 
 // ─── Data ────────────────────────────────────────────────────────────────────
 
@@ -175,6 +176,7 @@ export default function LandingPage() {
                     How It Works
                   </Button>
                 </Link>
+                <WalletButton />
               </div>
 
               {/* Trust signals */}


### PR DESCRIPTION
closes #51 

 Summary
  
  Adds a prominent "Connect Wallet" button to the landing page hero CTA row, enabling users to
  initiate Stellar wallet authentication directly from the landing page.
  
  Changes
  
  - app/page.tsx — Imported WalletButton and added it to the hero CTA row alongside "Get Started
  Free" and "How It Works"
  - app/layout.tsx — Fixed a bug where <Navbar /> and <main>{children}</main> were rendered
  twice (once inside ClientWalletProvider, once outside)
  
  Behaviour
  
  - Displays a gradient "Connect Wallet" button in the hero section
  - Opens a wallet selection modal (Freighter, Albedo, Lobstr) on click
  - Shows "Connecting..." loading state during connection
  - Updates global wallet context on success; button updates to show truncated public key
  - Clicking the connected button disconnects the wallet
  - Error messages surface in the modal if connection fails
  
  Notes
  
  The wallet state management (WalletProvider, useWallet) and WalletButton component were
  already implemented — this change exposes the button on the landing page and fixes the layout
  duplication bug.
