### PR TITLE
feat: responsive sidebar navigation (closes #65)

### DIFF
--- a/app/snippets/page.tsx
+++ b/app/snippets/page.tsx
@@ -15,7 +15,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Trash2, Copy, Plus } from "lucide-react";
-import { Navbar } from "@/components/navbar";
+import { Sidebar } from "@/components/Sidebar";
 import Loader from "@/components/ui/loader";
 import { VersionHistoryPanel } from "@/components/VersionHistory";
 
@@ -203,25 +203,19 @@ export default function SnippetsPage() {
   };
 
   return (
-    <div className="min-h-screen relative bg-linear-to-b from-slate-50 via-white to-white">
-      <div
-        aria-hidden
-        className="pointer-events-none absolute -top-32 -left-32 w-125 h-125 rounded-full bg-indigo-100/60 blur-3xl"
-      />
-      <div
-        aria-hidden
-        className="pointer-events-none absolute -top-16 right-0 w-100 h-100 rounded-full bg-violet-100/50 blur-3xl"
-      />
+    <div className="flex min-h-screen bg-gray-950">
+      <Sidebar />
 
+      <main className="flex-1 min-w-0 relative">
       <div className="fixed inset-0 overflow-hidden pointer-events-none">
         <div className="absolute top-20 left-10 w-72 h-72 bg-purple-600 rounded-full mix-blend-multiply filter blur-3xl opacity-20 animate-glow-pulse" />
         <div className="absolute top-40 right-10 w-72 h-72 bg-blue-600 rounded-full mix-blend-multiply filter blur-3xl opacity-20 animate-glow-pulse animation-delay-1000" />
       </div>
 
-      <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <div className="relative z-10 max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8 md:pl-8">
         {/* Page heading row */}
         <div className="flex items-center justify-between mb-8">
-          <h1 className="text-2xl font-bold text-slate-900  ">My Snippets</h1>
+          <h1 className="text-2xl font-bold text-white">My Snippets</h1>
           {!showForm && (
             <Button
               onClick={() => setShowForm(true)}
@@ -524,3 +518,8 @@ transition-all duration-200"
             )}
           </>
         )}
+      </div>
+      </main>
+    </div>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useState } from "react";
+import {
+	Code2,
+	Home,
+	FileCode2,
+	ChevronLeft,
+	ChevronRight,
+	Menu,
+	X,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const NAV_ITEMS = [
+	{ label: "Home", href: "/", icon: Home },
+	{ label: "Snippets", href: "/snippets", icon: FileCode2 },
+];
+
+export function Sidebar() {
+	const pathname = usePathname();
+	const [collapsed, setCollapsed] = useState(false);
+	const [mobileOpen, setMobileOpen] = useState(false);
+
+	return (
+		<>
+			{/* Mobile overlay */}
+			{mobileOpen && (
+				<div
+					className="fixed inset-0 z-40 bg-black/60 md:hidden"
+					onClick={() => setMobileOpen(false)}
+					aria-hidden="true"
+				/>
+			)}
+
+			{/* Mobile hamburger trigger */}
+			<button
+				className="fixed top-4 left-4 z-50 md:hidden p-2 rounded-lg bg-gray-900 border border-white/10 text-gray-300 hover:text-purple-400 transition-colors"
+				onClick={() => setMobileOpen(!mobileOpen)}
+				aria-label="Toggle sidebar">
+				{mobileOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
+			</button>
+
+			{/* Sidebar panel */}
+			<aside
+				className={cn(
+					// Base styles
+					"flex flex-col bg-gray-950 border-r border-white/10 h-screen sticky top-0 z-40",
+					// Smooth width transition
+					"transition-all duration-300 ease-in-out",
+					// Desktop: collapsible width
+					collapsed ? "w-16" : "w-56",
+					// Mobile: fixed overlay, slide in/out
+					"max-md:fixed max-md:top-0 max-md:left-0 max-md:h-full max-md:w-64 max-md:z-50",
+					mobileOpen ? "max-md:translate-x-0" : "max-md:-translate-x-full",
+				)}>
+				{/* Logo */}
+				<div className="flex items-center gap-2 px-4 py-5 border-b border-white/10 min-h-[64px]">
+					<Code2 className="w-6 h-6 text-purple-400 shrink-0" />
+					{(!collapsed || mobileOpen) && (
+						<span className="text-lg font-bold bg-gradient-to-r from-purple-400 to-blue-400 bg-clip-text text-transparent whitespace-nowrap overflow-hidden">
+							Codely
+						</span>
+					)}
+				</div>
+
+				{/* Nav items */}
+				<nav className="flex-1 px-2 py-4 flex flex-col gap-1">
+					{NAV_ITEMS.map(({ label, href, icon: Icon }) => {
+						const active = pathname === href;
+						return (
+							<Link
+								key={href}
+								href={href}
+								onClick={() => setMobileOpen(false)}
+								className={cn(
+									"flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors",
+									active
+										? "bg-purple-500/15 text-purple-400"
+										: "text-gray-400 hover:bg-white/5 hover:text-gray-200",
+								)}
+								title={collapsed && !mobileOpen ? label : undefined}>
+								<Icon className="w-5 h-5 shrink-0" />
+								{(!collapsed || mobileOpen) && (
+									<span className="whitespace-nowrap overflow-hidden">{label}</span>
+								)}
+								{active && (!collapsed || mobileOpen) && (
+									<span className="ml-auto w-1.5 h-1.5 rounded-full bg-purple-400" />
+								)}
+							</Link>
+						);
+					})}
+				</nav>
+
+				{/* Collapse toggle (desktop only) */}
+				<button
+					className="hidden md:flex items-center justify-center p-3 border-t border-white/10 text-gray-500 hover:text-purple-400 transition-colors"
+					onClick={() => setCollapsed(!collapsed)}
+					aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}>
+					{collapsed ? (
+						<ChevronRight className="w-4 h-4" />
+					) : (
+						<ChevronLeft className="w-4 h-4" />
+					)}
+				</button>
+			</aside>
+		</>
+	);
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -17,28 +17,26 @@ export function Navbar() {
 	const pathname = usePathname();
 	const [mobileOpen, setMobileOpen] = useState(false);
 
-	return
-		<header className='border-b border-white/10 backdrop-blur-md sticky top-0 z-50'>
-			<div className='max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between'>
+	return (
+		<header className="border-b border-white/10 backdrop-blur-md sticky top-0 z-50">
+			<div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between">
 				{/* Logo */}
 				<Link
-					href='/'
-					className='flex items-center gap-2 hover:opacity-80 transition'>
-					<Code2 className='w-7 h-7 text-purple-400' />
-					<span className='text-xl font-bold bg-gradient-to-r from-purple-400 to-blue-400 bg-clip-text text-transparent'>
+					href="/"
+					className="flex items-center gap-2 hover:opacity-80 transition">
+					<Code2 className="w-7 h-7 text-purple-400" />
+					<span className="text-xl font-bold bg-gradient-to-r from-purple-400 to-blue-400 bg-clip-text text-transparent">
 						Codely
 					</span>
 				</Link>
 
-				{/* Nav links & Wallet */}
-				<div className='flex items-center gap-4'>
-					<nav className='flex items-center gap-1'>
+				{/* Desktop nav links & Wallet */}
+				<div className="hidden md:flex items-center gap-4">
+					<nav className="flex items-center gap-1">
 						{NAV_LINKS.map(({ label, href }) => (
-							<Link
-								key={href}
-								href={href}>
+							<Link key={href} href={href}>
 								<Button
-									variant='ghost'
+									variant="ghost"
 									className={cn(
 										"text-sm font-medium transition-colors",
 										pathname === href
@@ -52,85 +50,38 @@ export function Navbar() {
 					</nav>
 					<WalletButton />
 				</div>
+
+				{/* Mobile menu button */}
+				<button
+					className="md:hidden text-gray-300 hover:text-purple-400 transition-colors"
+					onClick={() => setMobileOpen(!mobileOpen)}
+					aria-label="Toggle navigation menu">
+					{mobileOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
+				</button>
 			</div>
+
+			{/* Mobile menu */}
+			{mobileOpen && (
+				<div className="md:hidden border-t border-white/10 bg-black/80 backdrop-blur-md px-4 py-4 flex flex-col gap-2">
+					{NAV_LINKS.map(({ label, href }) => (
+						<Link key={href} href={href} onClick={() => setMobileOpen(false)}>
+							<Button
+								variant="ghost"
+								className={cn(
+									"w-full justify-start text-sm font-medium",
+									pathname === href
+										? "text-purple-400 bg-purple-400/10"
+										: "text-gray-300 hover:text-purple-400 hover:bg-purple-400/10",
+								)}>
+								{label}
+							</Button>
+						</Link>
+					))}
+					<div className="mt-2">
+						<WalletButton />
+					</div>
+				</div>
+			)}
 		</header>
 	);
-	  <header className="border-b border-slate-200 bg-white/90 backdrop-blur-md sticky top-0 z-50 shadow-[0_1px_3px_0_rgb(0,0,0,0.04)]">
-		  <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3.5 flex items-center justify-between">
-			  {/* Logo */}
-			  <Link href="/" className="flex items-center gap-2 hover:opacity-80 transition">
-				  <Code2 className="w-7 h-7 text-indigo-600" />
-				  <span className="text-xl font-bold bg-gradient-to-r from-indigo-600 to-violet-600 bg-clip-text text-transparent">
-					  Codely
-				  </span>
-			  </Link>
-
-			  {/* Desktop nav */}
-			  <nav className="hidden md:flex items-center gap-1">
-				  {NAV_LINKS.map(({ label, href }) => (
-			  <Link key={href} href={href}>
-				  <Button
-					  variant="ghost"
-					  className={cn(
-						  "text-sm font-medium transition-colors",
-						  pathname === href
-						? "text-indigo-600 bg-indigo-50"
-						: "text-slate-600 hover:text-indigo-600 hover:bg-indigo-50",
-				)}
-				  >
-					  {label}
-				  </Button>
-			  </Link>
-		  ))}
-			  </nav>
-
-			  {/* Desktop CTA */}
-			  <div className="hidden md:flex items-center gap-3">
-				  <Link href="/snippets">
-					  <Button
-						  size="sm"
-						  className="bg-indigo-600 hover:bg-indigo-700 text-white rounded-full px-5 font-semibold shadow-sm hover:shadow-md transition-all duration-200"
-					  >
-						  Get Started
-					  </Button>
-				  </Link>
-			  </div>
-
-			  {/* Mobile menu button */}
-			  <button
-				  className="md:hidden text-slate-600 hover:text-indigo-600 transition-colors"
-				  onClick={() => setMobileOpen(!mobileOpen)}
-				  aria-label="Toggle navigation menu"
-			  >
-				  {mobileOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
-			  </button>
-		  </div>
-
-		  {/* Mobile menu */}
-		  {mobileOpen && (
-			  <div className="md:hidden border-t border-slate-100 bg-white px-4 py-4 flex flex-col gap-2">
-				  {NAV_LINKS.map(({ label, href }) => (
-					  <Link key={href} href={href} onClick={() => setMobileOpen(false)}>
-						  <Button
-							  variant="ghost"
-							  className={cn(
-								  "w-full justify-start text-sm font-medium",
-								  pathname === href
-									  ? "text-indigo-600 bg-indigo-50"
-									  : "text-slate-600 hover:text-indigo-600 hover:bg-indigo-50",
-							  )}
-						  >
-							  {label}
-						  </Button>
-					  </Link>
-				  ))}
-				  <Link href="/snippets" onClick={() => setMobileOpen(false)}>
-					  <Button className="w-full mt-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-full font-semibold">
-						  Get Started
-					  </Button>
-				  </Link>
-			  </div>
-		  )}
-	  </header>
-  )
 }


### PR DESCRIPTION
Closes #65

---

## Summary

Implements responsive sidebar navigation for dashboard pages as requested in #65.

### Changes

- **Fix `navbar.tsx`**: Had two `return` statements — the first was missing JSX parentheses so it returned `undefined`, the second was dead code. Consolidated into a single clean return with dark theme, desktop nav, and mobile hamburger menu.

- **New `Sidebar` component** (`components/Sidebar.tsx`):
  - Collapsible on desktop (chevron toggle, animates between `w-16` and `w-56`)
  - Mobile overlay with hamburger button (fixed position, slides in/out)
  - Active route highlighting with purple indicator dot
  - Smooth CSS transitions for all expand/collapse states

- **Snippets page** (`app/snippets/page.tsx`):
  - Replaced `Navbar` import with `Sidebar`
  - Wrapped content in `flex` layout with sidebar on left, main content on right
  - Fixed heading text color (`text-slate-900` → `text-white`) for dark background

### Tested
- Zero TypeScript errors in changed files
- Pre-existing build errors in `lib/db.ts` exports are unrelated to this PR