### PR TITLE
feat(wallet): add Stellar testnet faucet UI and authenticated faucet …

### DIFF
--- a/app/api/wallet/faucet/route.ts
+++ b/app/api/wallet/faucet/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest, NextResponse } from "next/server";
+import { withAuth } from "@/lib/auth-middleware";
+import { rateLimit } from "@/lib/rateLimiter";
+
+const FAUCET_RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000; // 10 minutes
+const FAUCET_RATE_LIMIT_MAX_REQUESTS = 1;
+
+async function faucetHandler(req: NextRequest) {
+  if (req.method !== "POST") {
+    return NextResponse.json(
+      { error: "Method not allowed" },
+      { status: 405 },
+    );
+  }
+
+  const auth = (req as any).auth;
+  const walletAddress = auth?.walletAddress;
+
+  if (!walletAddress) {
+    return NextResponse.json(
+      { error: "Unauthorized - wallet address is required" },
+      { status: 401 },
+    );
+  }
+
+  const limit = rateLimit(`faucet-request:${walletAddress}`, {
+    windowMs: FAUCET_RATE_LIMIT_WINDOW_MS,
+    max: FAUCET_RATE_LIMIT_MAX_REQUESTS,
+  });
+
+  if (!limit.allowed) {
+    return NextResponse.json(
+      {
+        error: "Faucet request rate limit exceeded. Please try again later.",
+        limit: limit.limit,
+        window: limit.window,
+      },
+      { status: 429 },
+    );
+  }
+
+  try {
+    const response = await fetch(
+      `https://friendbot.stellar.org?addr=${encodeURIComponent(walletAddress)}`,
+      {
+        method: "GET",
+      },
+    );
+
+    const result = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(
+        {
+          error:
+            result?.error || result?.detail ||
+            "Stellar friendbot request failed.",
+        },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: "Stellar testnet tokens requested successfully.",
+      details: result,
+    });
+  } catch (error: any) {
+    console.error("[wallet/faucet] error:", error);
+    return NextResponse.json(
+      {
+        error: error?.message || "Failed to request Stellar testnet tokens.",
+      },
+      { status: 500 },
+    );
+  }
+}
+
+export const POST = withAuth(faucetHandler);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Analytics } from "@vercel/analytics/next";
+import { Toaster } from "sonner";
 import ClientWalletProvider from "@/components/ClientWalletProvider";
 import "./globals.css";
 
@@ -41,6 +42,7 @@ export default function RootLayout({
 				<ClientWalletProvider>
 					{children}
 				</ClientWalletProvider>
+				<Toaster position="top-right" richColors />
 				<Analytics />
 			</body>
 		</html>

--- a/components/WalletConnect.tsx
+++ b/components/WalletConnect.tsx
@@ -10,6 +10,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { toast } from "sonner";
 
 declare global {
   interface Window {
@@ -220,6 +221,10 @@ export const useWallet = () => useContext(WalletContext);
 export function WalletButton() {
   const wallet = useWallet();
   const [showModal, setShowModal] = useState(false);
+  const [showStatusDialog, setShowStatusDialog] = useState(false);
+  const [balance, setBalance] = useState<string | null>(null);
+  const [balanceLoading, setBalanceLoading] = useState(false);
+  const [faucetLoading, setFaucetLoading] = useState(false);
 
   if (!wallet) return null;
 
@@ -231,7 +236,71 @@ export function WalletButton() {
     disconnect,
     error,
     clearError,
+    token,
   } = wallet;
+
+  const fetchWalletBalance = async (address: string) => {
+    setBalanceLoading(true);
+    try {
+      const response = await fetch(`https://horizon-testnet.stellar.org/accounts/${encodeURIComponent(address)}`);
+      if (!response.ok) {
+        setBalance("0.00");
+        return;
+      }
+
+      const account = await response.json();
+      const nativeBalance = account.balances?.find((item: any) => item.asset_type === "native")?.balance;
+      setBalance(nativeBalance ?? "0.00");
+    } catch (err) {
+      console.error("Error fetching wallet balance:", err);
+      setBalance("0.00");
+    } finally {
+      setBalanceLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (connected && publicKey) {
+      fetchWalletBalance(publicKey);
+    }
+  }, [connected, publicKey]);
+
+  const handleRequestFaucet = async () => {
+    if (!publicKey) {
+      toast.error("Wallet address unavailable.");
+      return;
+    }
+
+    setFaucetLoading(true);
+    try {
+      const response = await fetch("/api/wallet/faucet", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+      });
+
+      const result = await response.json();
+      if (!response.ok) {
+        throw new Error(result?.error || "Failed to request Stellar testnet tokens.");
+      }
+
+      toast.success("Testnet tokens requested successfully.");
+      await fetchWalletBalance(publicKey);
+    } catch (err: any) {
+      console.error("Faucet request failed:", err);
+      toast.error(err?.message || "Failed to request Stellar testnet tokens.");
+    } finally {
+      setFaucetLoading(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    setShowStatusDialog(false);
+    setBalance(null);
+    await disconnect();
+  };
 
   const handleWalletSelect = async (
     walletType: "freighter" | "albedo" | "lobstr",
@@ -247,15 +316,54 @@ export function WalletButton() {
 
   if (connected && publicKey) {
     return (
-      <Button
-        onClick={disconnect}
-        variant="outline"
-        size="sm"
-        className="bg-purple-500/10 border-purple-500/20 text-purple-300 hover:bg-purple-500/20 hover:text-purple-200 gap-2"
-      >
-        <Wallet className="w-4 h-4" />
-        {publicKey.slice(0, 4)}...{publicKey.slice(-4)}
-      </Button>
+      <>
+        <Button
+          onClick={() => setShowStatusDialog(true)}
+          variant="outline"
+          size="sm"
+          className="bg-purple-500/10 border-purple-500/20 text-purple-300 hover:bg-purple-500/20 hover:text-purple-200 gap-2"
+        >
+          <Wallet className="w-4 h-4" />
+          {publicKey.slice(0, 4)}...{publicKey.slice(-4)}
+        </Button>
+
+        <Dialog open={showStatusDialog} onOpenChange={setShowStatusDialog}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Wallet</DialogTitle>
+              <DialogDescription>
+                View connected wallet details and request Stellar testnet tokens.
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="space-y-4 py-4">
+              <div className="rounded-2xl border border-slate-800 bg-slate-950 p-4">
+                <p className="text-xs uppercase tracking-[0.2em] text-slate-400">Connected wallet</p>
+                <p className="mt-2 font-mono text-sm text-white break-all">{publicKey}</p>
+                <p className="mt-3 text-sm text-slate-300">
+                  Balance: {balanceLoading ? "Loading..." : balance ? `${balance} XLM` : "Unavailable"}
+                </p>
+              </div>
+
+              <Button
+                onClick={handleRequestFaucet}
+                disabled={faucetLoading}
+                className="w-full bg-gradient-to-r from-indigo-500 to-violet-500 text-white"
+              >
+                {faucetLoading ? "Requesting tokens..." : "Request Testnet Tokens"}
+              </Button>
+
+              <Button
+                onClick={handleDisconnect}
+                variant="outline"
+                className="w-full"
+              >
+                Disconnect Wallet
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      </>
     );
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "react-resizable-panels": "^2.1.7",
         "recharts": "2.15.4",
         "sonner": "^1.7.4",
+        "stellar-sdk": "^12.1.0",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
         "vaul": "^1.1.2",
@@ -773,6 +774,20 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@creit-tech/stellar-wallets-kit/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/@creit.tech/xbull-wallet-connect": {
@@ -16644,6 +16659,37 @@
       "peer": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/stellar-sdk": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/stellar-sdk/-/stellar-sdk-12.3.0.tgz",
+      "integrity": "sha512-3z7umyuBAHN+vm3zLTKqj7P/bErBFnjrwoanBsNyBHaoek9krUgufNupQSMK67B1p0E2NKD1Z6gYPuZiPfJ2qQ==",
+      "deprecated": "⚠️ This package has moved to @stellar/stellar-sdk! 🚚",
+      "dependencies": {
+        "@stellar/stellar-base": "^12.1.1",
+        "axios": "^1.7.7",
+        "bignumber.js": "^9.1.2",
+        "eventsource": "^2.0.2",
+        "randombytes": "^2.1.0",
+        "toml": "^3.0.0",
+        "urijs": "^1.19.1"
+      }
+    },
+    "node_modules/stellar-sdk/node_modules/@stellar/stellar-base": {
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/@stellar/stellar-base/-/stellar-base-12.1.1.tgz",
+      "integrity": "sha512-gOBSOFDepihslcInlqnxKZdIW9dMUO1tpOm3AtJR33K2OvpXG6SaVHCzAmCFArcCqI9zXTEiSoh70T48TmiHJA==",
+      "dependencies": {
+        "@stellar/js-xdr": "^3.1.2",
+        "base32.js": "^0.1.0",
+        "bignumber.js": "^9.1.2",
+        "buffer": "^6.0.3",
+        "sha.js": "^2.3.6",
+        "tweetnacl": "^1.0.3"
+      },
+      "optionalDependencies": {
+        "sodium-native": "^4.1.1"
       }
     },
     "node_modules/stream-browserify": {


### PR DESCRIPTION
Close #74 




## PR Description

### Summary
This PR adds Stellar testnet faucet integration to CodeCodely so users can request testnet XLM directly from the app after connecting a wallet.

### What changed
- WalletConnect.tsx
  - Added wallet status dialog for connected users
  - Added testnet balance display using Horizon Testnet account lookup
  - Added `Request Testnet Tokens` button
  - Added toast notifications for faucet success/error
- route.ts
  - New authenticated POST endpoint at `/api/wallet/faucet`
  - Uses JWT auth to secure faucet requests
  - Uses Stellar Friendbot to fund the connected wallet
  - Adds rate limiting: 1 request per wallet every 10 minutes
- layout.tsx
  - Added global `Toaster` from `sonner` so notification UI works app-wide

### Files changed
- WalletConnect.tsx
- route.ts
- layout.tsx

### Testing
1. Run `npm run dev`
2. Connect a Stellar wallet
3. Open the connected wallet dialog
4. Click `Request Testnet Tokens`
5. Confirm:
   - success toast appears
   - wallet balance refreshes
   - repeated faucet attempts are blocked by rate limiting
