### PR TITLE
feat(blockchain): add Stellar event listener sync

### DIFF
--- a/app/api/cron/blockchain-events/route.ts
+++ b/app/api/cron/blockchain-events/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from "next/server";
+import { BlockchainEventListenerRepository } from "@/lib/blockchain-event-listener.repository";
+import {
+  BlockchainEventListenerService,
+  HttpBlockchainEventSource,
+} from "@/lib/blockchain-event-listener.service";
+
+export const runtime = "nodejs";
+
+export async function GET(request: Request) {
+  try {
+    const authHeader = request.headers.get("authorization");
+
+    if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const service = new BlockchainEventListenerService(
+      new BlockchainEventListenerRepository(),
+      new HttpBlockchainEventSource(),
+    );
+    const summary = await service.sync();
+
+    return NextResponse.json({
+      success: true,
+      message: "Blockchain events synchronized successfully",
+      data: summary,
+    });
+  } catch (error) {
+    console.error("[Cron/BlockchainEvents] Error:", error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : "Blockchain sync failed",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/lib/blockchain-event-listener.repository.ts
+++ b/lib/blockchain-event-listener.repository.ts
@@ -1,0 +1,390 @@
+import { neon } from "@neondatabase/serverless";
+import type {
+  BlockchainEvent,
+  EventLogStatus,
+  PermissionType,
+  StoredBlockchainEvent,
+} from "@/lib/blockchain-event-listener.types";
+
+const DEFAULT_STREAM_NAME = "stellar-app-events";
+
+let sql: ReturnType<typeof neon> | null = null;
+
+function getSql() {
+  if (!sql) {
+    if (!process.env.DATABASE_URL) {
+      throw new Error("DATABASE_URL environment variable is not set");
+    }
+    sql = neon(process.env.DATABASE_URL);
+  }
+  return sql;
+}
+
+type EventLogRow = {
+  event_id: string;
+  event_type: string;
+  status: EventLogStatus;
+  attempts: number;
+  source: string | null;
+  last_error: string | null;
+  payload: BlockchainEvent;
+};
+
+function toStoredEvent(row: EventLogRow): StoredBlockchainEvent {
+  return {
+    ...row.payload,
+    status: row.status,
+    attempts: Number(row.attempts ?? 0),
+    source: row.source,
+    lastError: row.last_error,
+  };
+}
+
+export class BlockchainEventListenerRepository {
+  async getCursor(streamName = DEFAULT_STREAM_NAME): Promise<string | null> {
+    const result = (await getSql()`
+      SELECT cursor
+      FROM blockchain_event_cursors
+      WHERE stream_name = ${streamName}
+      LIMIT 1
+    `) as Array<{ cursor: string }>;
+    return result[0]?.cursor ?? null;
+  }
+
+  async saveCursor(
+    streamName = DEFAULT_STREAM_NAME,
+    cursor: string,
+  ): Promise<void> {
+    await getSql()`
+      INSERT INTO blockchain_event_cursors (stream_name, cursor, updated_at)
+      VALUES (${streamName}, ${cursor}, NOW())
+      ON CONFLICT (stream_name)
+      DO UPDATE SET
+        cursor = EXCLUDED.cursor,
+        updated_at = NOW()
+    `;
+  }
+
+  async upsertEventLog(
+    event: BlockchainEvent,
+    source: string | null = null,
+  ): Promise<StoredBlockchainEvent> {
+    const payload = JSON.stringify(event);
+    const result = (await getSql()`
+      INSERT INTO blockchain_event_logs (
+        event_id,
+        event_type,
+        cursor,
+        tx_hash,
+        contract_id,
+        source,
+        status,
+        attempts,
+        payload,
+        created_at,
+        updated_at
+      )
+      VALUES (
+        ${event.id},
+        ${event.type},
+        ${event.cursor ?? null},
+        ${event.txHash ?? null},
+        ${event.contractId ?? null},
+        ${source},
+        'pending',
+        0,
+        ${payload}::jsonb,
+        NOW(),
+        NOW()
+      )
+      ON CONFLICT (event_id)
+      DO UPDATE SET
+        cursor = COALESCE(EXCLUDED.cursor, blockchain_event_logs.cursor),
+        tx_hash = COALESCE(EXCLUDED.tx_hash, blockchain_event_logs.tx_hash),
+        contract_id = COALESCE(EXCLUDED.contract_id, blockchain_event_logs.contract_id),
+        source = COALESCE(EXCLUDED.source, blockchain_event_logs.source),
+        payload = EXCLUDED.payload,
+        updated_at = NOW()
+      RETURNING event_id, event_type, status, attempts, source, last_error, payload
+    `) as EventLogRow[];
+
+    return toStoredEvent(result[0]);
+  }
+
+  async getRetryableEvents(limit: number): Promise<StoredBlockchainEvent[]> {
+    const result = await getSql()`
+      SELECT event_id, event_type, status, attempts, source, last_error, payload
+      FROM blockchain_event_logs
+      WHERE status = 'retrying'
+      ORDER BY updated_at ASC
+      LIMIT ${limit}
+    `;
+
+    return (result as EventLogRow[]).map(toStoredEvent);
+  }
+
+  async markProcessing(eventId: string): Promise<void> {
+    await getSql()`
+      UPDATE blockchain_event_logs
+      SET status = 'processing',
+          updated_at = NOW()
+      WHERE event_id = ${eventId}
+    `;
+  }
+
+  async markProcessed(eventId: string): Promise<void> {
+    await getSql()`
+      UPDATE blockchain_event_logs
+      SET status = 'processed',
+          processed_at = NOW(),
+          last_error = null,
+          updated_at = NOW()
+      WHERE event_id = ${eventId}
+    `;
+  }
+
+  async markIgnored(eventId: string, reason: string): Promise<void> {
+    await getSql()`
+      UPDATE blockchain_event_logs
+      SET status = 'ignored',
+          processed_at = NOW(),
+          last_error = ${reason},
+          updated_at = NOW()
+      WHERE event_id = ${eventId}
+    `;
+  }
+
+  async markRetrying(eventId: string, errorMessage: string): Promise<void> {
+    await getSql()`
+      UPDATE blockchain_event_logs
+      SET status = 'retrying',
+          attempts = attempts + 1,
+          last_error = ${errorMessage},
+          updated_at = NOW()
+      WHERE event_id = ${eventId}
+    `;
+  }
+
+  async markFailed(eventId: string, errorMessage: string): Promise<void> {
+    await getSql()`
+      UPDATE blockchain_event_logs
+      SET status = 'failed',
+          attempts = attempts + 1,
+          last_error = ${errorMessage},
+          updated_at = NOW()
+      WHERE event_id = ${eventId}
+    `;
+  }
+
+  async syncSnippetOwnership(params: {
+    snippetId: string;
+    newOwnerWalletAddress: string;
+    previousOwnerWalletAddress?: string | null;
+    txHash?: string | null;
+    timestamp: string;
+    metadata?: Record<string, unknown> | null;
+  }): Promise<void> {
+    const occurredAt = new Date(params.timestamp);
+
+    const result = (params.previousOwnerWalletAddress
+      ? await getSql()`
+          UPDATE snippets
+          SET owner_wallet_address = ${params.newOwnerWalletAddress},
+              updated_at = ${occurredAt}
+          WHERE id = ${params.snippetId}
+            AND owner_wallet_address = ${params.previousOwnerWalletAddress}
+          RETURNING id
+        `
+      : await getSql()`
+          UPDATE snippets
+          SET owner_wallet_address = ${params.newOwnerWalletAddress},
+              updated_at = ${occurredAt}
+          WHERE id = ${params.snippetId}
+          RETURNING id
+        `) as Array<{ id: string }>;
+
+    if (result.length === 0) {
+      throw new Error("Snippet ownership sync failed: snippet missing or owner mismatch");
+    }
+
+    const listingId = this.readMetadataString(params.metadata, "listingId");
+    const purchaseId = this.readMetadataString(params.metadata, "purchaseId");
+
+    if (listingId) {
+      await getSql()`
+        UPDATE marketplace_listings
+        SET status = 'sold',
+            updated_at = ${occurredAt}
+        WHERE id = ${listingId}
+      `;
+    }
+
+    if (purchaseId) {
+      await getSql()`
+        UPDATE marketplace_purchases
+        SET status = 'completed',
+            release_tx_hash = COALESCE(${params.txHash ?? null}, release_tx_hash),
+            completed_at = COALESCE(completed_at, ${occurredAt})
+        WHERE id = ${purchaseId}
+      `;
+
+      await getSql()`
+        UPDATE marketplace_escrow
+        SET status = 'released',
+            release_tx_hash = COALESCE(${params.txHash ?? null}, release_tx_hash),
+            released_at = COALESCE(released_at, ${occurredAt})
+        WHERE purchase_id = ${purchaseId}
+      `;
+    }
+  }
+
+  async upsertWalletVerification(params: {
+    walletAddress: string;
+    txHash?: string | null;
+    timestamp: string;
+    metadata?: Record<string, unknown> | null;
+  }): Promise<void> {
+    await getSql()`
+      INSERT INTO wallet_identity_verifications (
+        wallet_address,
+        status,
+        last_verified_at,
+        tx_hash,
+        metadata,
+        created_at,
+        updated_at
+      )
+      VALUES (
+        ${params.walletAddress},
+        'verified',
+        ${new Date(params.timestamp)},
+        ${params.txHash ?? null},
+        ${JSON.stringify(params.metadata ?? {})}::jsonb,
+        NOW(),
+        NOW()
+      )
+      ON CONFLICT (wallet_address)
+      DO UPDATE SET
+        status = 'verified',
+        last_verified_at = EXCLUDED.last_verified_at,
+        tx_hash = COALESCE(EXCLUDED.tx_hash, wallet_identity_verifications.tx_hash),
+        metadata = EXCLUDED.metadata,
+        updated_at = NOW()
+    `;
+  }
+
+  async recordSnippetVerification(params: {
+    snippetId: string;
+    walletAddress: string;
+    signature?: string | null;
+    message?: string | null;
+    txHash?: string | null;
+    timestamp: string;
+  }): Promise<void> {
+    await getSql()`
+      INSERT INTO snippet_verifications (
+        snippet_id,
+        wallet_address,
+        signature,
+        message,
+        verified_at,
+        status,
+        is_active,
+        created_at
+      )
+      VALUES (
+        ${params.snippetId},
+        ${params.walletAddress},
+        ${params.signature ?? params.txHash ?? "blockchain-event"},
+        ${params.message ?? `On-chain verification synced from ${params.txHash ?? "unknown transaction"}`},
+        ${new Date(params.timestamp)},
+        'verified',
+        true,
+        NOW()
+      )
+    `;
+  }
+
+  async syncPermission(params: {
+    snippetId: string;
+    targetWalletAddress: string;
+    actorWalletAddress: string;
+    permissionType: PermissionType;
+    active: boolean;
+    txHash?: string | null;
+    timestamp: string;
+  }): Promise<void> {
+    const occurredAt = new Date(params.timestamp);
+
+    if (params.active) {
+      await getSql()`
+        INSERT INTO snippet_permissions (
+          snippet_id,
+          grantee_wallet_address,
+          permission_type,
+          granted_by_wallet_address,
+          on_chain_tx_hash,
+          granted_at,
+          revoked_at,
+          is_active
+        )
+        VALUES (
+          ${params.snippetId},
+          ${params.targetWalletAddress},
+          ${params.permissionType},
+          ${params.actorWalletAddress},
+          ${params.txHash ?? null},
+          ${occurredAt},
+          null,
+          true
+        )
+        ON CONFLICT (snippet_id, grantee_wallet_address, permission_type)
+        DO UPDATE SET
+          granted_by_wallet_address = EXCLUDED.granted_by_wallet_address,
+          on_chain_tx_hash = COALESCE(EXCLUDED.on_chain_tx_hash, snippet_permissions.on_chain_tx_hash),
+          granted_at = EXCLUDED.granted_at,
+          revoked_at = null,
+          is_active = true
+      `;
+    } else {
+      await getSql()`
+        UPDATE snippet_permissions
+        SET is_active = false,
+            revoked_at = ${occurredAt},
+            on_chain_tx_hash = COALESCE(${params.txHash ?? null}, on_chain_tx_hash)
+        WHERE snippet_id = ${params.snippetId}
+          AND grantee_wallet_address = ${params.targetWalletAddress}
+          AND permission_type = ${params.permissionType}
+      `;
+    }
+
+    await getSql()`
+      INSERT INTO permission_activity_log (
+        snippet_id,
+        actor_wallet_address,
+        target_wallet_address,
+        action,
+        permission_type,
+        on_chain_tx_hash,
+        created_at
+      )
+      VALUES (
+        ${params.snippetId},
+        ${params.actorWalletAddress},
+        ${params.targetWalletAddress},
+        ${params.active ? "grant" : "revoke"},
+        ${params.permissionType},
+        ${params.txHash ?? null},
+        ${occurredAt}
+      )
+    `;
+  }
+
+  private readMetadataString(
+    metadata: Record<string, unknown> | null | undefined,
+    key: string,
+  ): string | null {
+    const value = metadata?.[key];
+    return typeof value === "string" && value.length > 0 ? value : null;
+  }
+}

--- a/lib/blockchain-event-listener.service.test.ts
+++ b/lib/blockchain-event-listener.service.test.ts
@@ -1,0 +1,198 @@
+import type {
+  BlockchainEvent,
+  BlockchainEventSource,
+  StoredBlockchainEvent,
+} from "@/lib/blockchain-event-listener.types";
+import type { BlockchainEventListenerRepositoryLike } from "@/lib/blockchain-event-listener.service";
+import { BlockchainEventListenerService } from "@/lib/blockchain-event-listener.service";
+
+function createStoredEvent(
+  event: BlockchainEvent,
+  overrides: Partial<StoredBlockchainEvent> = {},
+): StoredBlockchainEvent {
+  return {
+    ...event,
+    status: overrides.status ?? "pending",
+    attempts: overrides.attempts ?? 0,
+    source: overrides.source ?? "test-source",
+    lastError: overrides.lastError ?? null,
+  };
+}
+
+describe("BlockchainEventListenerService", () => {
+  let repository: jest.Mocked<BlockchainEventListenerRepositoryLike>;
+  let source: jest.Mocked<BlockchainEventSource>;
+
+  beforeEach(() => {
+    repository = {
+      getCursor: jest.fn().mockResolvedValue("cursor-1"),
+      saveCursor: jest.fn().mockResolvedValue(undefined),
+      upsertEventLog: jest.fn(),
+      getRetryableEvents: jest.fn().mockResolvedValue([]),
+      markProcessing: jest.fn().mockResolvedValue(undefined),
+      markProcessed: jest.fn().mockResolvedValue(undefined),
+      markIgnored: jest.fn().mockResolvedValue(undefined),
+      markRetrying: jest.fn().mockResolvedValue(undefined),
+      markFailed: jest.fn().mockResolvedValue(undefined),
+      syncSnippetOwnership: jest.fn().mockResolvedValue(undefined),
+      upsertWalletVerification: jest.fn().mockResolvedValue(undefined),
+      recordSnippetVerification: jest.fn().mockResolvedValue(undefined),
+      syncPermission: jest.fn().mockResolvedValue(undefined),
+    };
+
+    source = {
+      fetchEvents: jest.fn().mockResolvedValue({
+        events: [],
+        nextCursor: "cursor-1",
+        source: "test-source",
+      }),
+    };
+  });
+
+  it("processes ownership transfer events and saves the newest cursor", async () => {
+    const event: BlockchainEvent = {
+      id: "evt-1",
+      type: "snippet.transferred",
+      timestamp: "2026-07-24T00:00:00.000Z",
+      cursor: "cursor-2",
+      txHash: "tx-1",
+      snippetId: "snippet-1",
+      previousOwnerWalletAddress: "GOLDOWNER12345678901234567890123456789012345678901234567",
+      newOwnerWalletAddress: "GNEWOWNER12345678901234567890123456789012345678901234567",
+      metadata: { purchaseId: "purchase-1" },
+    };
+
+    source.fetchEvents.mockResolvedValue({
+      events: [event],
+      nextCursor: "cursor-2",
+      source: "test-source",
+    });
+    repository.upsertEventLog.mockResolvedValue(createStoredEvent(event));
+
+    const service = new BlockchainEventListenerService(repository, source);
+    const summary = await service.sync();
+
+    expect(repository.syncSnippetOwnership).toHaveBeenCalledWith({
+      snippetId: "snippet-1",
+      newOwnerWalletAddress:
+        "GNEWOWNER12345678901234567890123456789012345678901234567",
+      previousOwnerWalletAddress:
+        "GOLDOWNER12345678901234567890123456789012345678901234567",
+      txHash: "tx-1",
+      timestamp: "2026-07-24T00:00:00.000Z",
+      metadata: { purchaseId: "purchase-1" },
+    });
+    expect(repository.markProcessed).toHaveBeenCalledWith("evt-1");
+    expect(repository.saveCursor).toHaveBeenCalledWith(
+      "stellar-app-events",
+      "cursor-2",
+    );
+    expect(summary).toMatchObject({
+      processed: 1,
+      duplicates: 0,
+      failed: 0,
+      cursor: "cursor-2",
+    });
+  });
+
+  it("skips events that were already processed", async () => {
+    const event: BlockchainEvent = {
+      id: "evt-duplicate",
+      type: "verification.wallet",
+      timestamp: "2026-07-24T00:00:00.000Z",
+      cursor: "cursor-2",
+      walletAddress: "GWALLET123456789012345678901234567890123456789012345678",
+    };
+
+    source.fetchEvents.mockResolvedValue({
+      events: [event],
+      nextCursor: "cursor-2",
+      source: "test-source",
+    });
+    repository.upsertEventLog.mockResolvedValue(
+      createStoredEvent(event, { status: "processed" }),
+    );
+
+    const service = new BlockchainEventListenerService(repository, source);
+    const summary = await service.sync();
+
+    expect(repository.markProcessing).not.toHaveBeenCalled();
+    expect(repository.upsertWalletVerification).not.toHaveBeenCalled();
+    expect(summary).toMatchObject({
+      processed: 0,
+      duplicates: 1,
+      failed: 0,
+    });
+  });
+
+  it("retries transient failures from the retry queue before fetching new events", async () => {
+    const retryEvent: BlockchainEvent = {
+      id: "evt-retry",
+      type: "permission.granted",
+      timestamp: "2026-07-24T00:00:00.000Z",
+      cursor: "cursor-retry",
+      txHash: "tx-retry",
+      snippetId: "snippet-9",
+      actorWalletAddress: "GACTOR1234567890123456789012345678901234567890123456789",
+      targetWalletAddress: "GTARGET123456789012345678901234567890123456789012345678",
+      permissionType: "edit",
+    };
+
+    repository.getRetryableEvents.mockResolvedValue([
+      createStoredEvent(retryEvent, { status: "retrying", attempts: 1 }),
+    ]);
+    repository.upsertEventLog.mockResolvedValue(
+      createStoredEvent(retryEvent, { status: "retrying", attempts: 1 }),
+    );
+
+    const service = new BlockchainEventListenerService(repository, source);
+    const summary = await service.sync();
+
+    expect(repository.syncPermission).toHaveBeenCalledWith({
+      snippetId: "snippet-9",
+      targetWalletAddress:
+        "GTARGET123456789012345678901234567890123456789012345678",
+      actorWalletAddress:
+        "GACTOR1234567890123456789012345678901234567890123456789",
+      permissionType: "edit",
+      active: true,
+      txHash: "tx-retry",
+      timestamp: "2026-07-24T00:00:00.000Z",
+    });
+    expect(summary).toMatchObject({
+      processed: 1,
+      retried: 1,
+      failed: 0,
+    });
+  });
+
+  it("marks malformed events as permanently failed", async () => {
+    const malformedEvent: BlockchainEvent = {
+      id: "evt-bad",
+      type: "verification.snippet",
+      timestamp: "2026-07-24T00:00:00.000Z",
+      cursor: "cursor-3",
+      walletAddress: "GWALLET123456789012345678901234567890123456789012345678",
+    };
+
+    source.fetchEvents.mockResolvedValue({
+      events: [malformedEvent],
+      nextCursor: "cursor-3",
+      source: "test-source",
+    });
+    repository.upsertEventLog.mockResolvedValue(createStoredEvent(malformedEvent));
+
+    const service = new BlockchainEventListenerService(repository, source);
+    const summary = await service.sync();
+
+    expect(repository.markFailed).toHaveBeenCalledWith(
+      "evt-bad",
+      "Missing required event field: snippetId",
+    );
+    expect(repository.markRetrying).not.toHaveBeenCalled();
+    expect(summary).toMatchObject({
+      processed: 0,
+      failed: 1,
+    });
+  });
+});

--- a/lib/blockchain-event-listener.service.ts
+++ b/lib/blockchain-event-listener.service.ts
@@ -1,0 +1,419 @@
+import crypto from "crypto";
+import type {
+  BlockchainEvent,
+  BlockchainEventBatch,
+  BlockchainEventSource,
+  PermissionType,
+  StoredBlockchainEvent,
+} from "@/lib/blockchain-event-listener.types";
+import { BlockchainEventListenerRepository } from "@/lib/blockchain-event-listener.repository";
+
+export interface BlockchainEventListenerRepositoryLike {
+  getCursor(streamName?: string): Promise<string | null>;
+  saveCursor(streamName: string, cursor: string): Promise<void>;
+  upsertEventLog(
+    event: BlockchainEvent,
+    source?: string | null,
+  ): Promise<StoredBlockchainEvent>;
+  getRetryableEvents(limit: number): Promise<StoredBlockchainEvent[]>;
+  markProcessing(eventId: string): Promise<void>;
+  markProcessed(eventId: string): Promise<void>;
+  markIgnored(eventId: string, reason: string): Promise<void>;
+  markRetrying(eventId: string, errorMessage: string): Promise<void>;
+  markFailed(eventId: string, errorMessage: string): Promise<void>;
+  syncSnippetOwnership(params: {
+    snippetId: string;
+    newOwnerWalletAddress: string;
+    previousOwnerWalletAddress?: string | null;
+    txHash?: string | null;
+    timestamp: string;
+    metadata?: Record<string, unknown> | null;
+  }): Promise<void>;
+  upsertWalletVerification(params: {
+    walletAddress: string;
+    txHash?: string | null;
+    timestamp: string;
+    metadata?: Record<string, unknown> | null;
+  }): Promise<void>;
+  recordSnippetVerification(params: {
+    snippetId: string;
+    walletAddress: string;
+    signature?: string | null;
+    message?: string | null;
+    txHash?: string | null;
+    timestamp: string;
+  }): Promise<void>;
+  syncPermission(params: {
+    snippetId: string;
+    targetWalletAddress: string;
+    actorWalletAddress: string;
+    permissionType: PermissionType;
+    active: boolean;
+    txHash?: string | null;
+    timestamp: string;
+  }): Promise<void>;
+}
+
+export interface SyncSummary {
+  cursor: string | null;
+  processed: number;
+  retried: number;
+  duplicates: number;
+  ignored: number;
+  failed: number;
+  fetched: number;
+}
+
+class IgnoredEventError extends Error {}
+class PermanentSyncError extends Error {}
+
+export class HttpBlockchainEventSource implements BlockchainEventSource {
+  constructor(
+    private readonly endpoint = process.env.STELLAR_EVENT_SOURCE_URL,
+    private readonly apiKey = process.env.STELLAR_EVENT_SOURCE_API_KEY,
+    private readonly fetchImpl: typeof fetch = fetch,
+  ) {}
+
+  async fetchEvents(params: {
+    cursor?: string | null;
+    limit: number;
+  }): Promise<BlockchainEventBatch> {
+    if (!this.endpoint) {
+      return {
+        events: [],
+        nextCursor: params.cursor ?? null,
+        source: "env:STELLAR_EVENT_SOURCE_URL:not-configured",
+      };
+    }
+
+    const url = new URL(this.endpoint);
+    url.searchParams.set("limit", String(params.limit));
+    if (params.cursor) {
+      url.searchParams.set("cursor", params.cursor);
+    }
+
+    const headers: HeadersInit = {};
+    if (this.apiKey) {
+      headers.authorization = `Bearer ${this.apiKey}`;
+    }
+
+    const response = await this.fetchImpl(url.toString(), {
+      method: "GET",
+      headers,
+      cache: "no-store",
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Event source request failed with ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const payload = await response.json();
+    const rawEvents = Array.isArray(payload)
+      ? payload
+      : Array.isArray(payload?.events)
+        ? payload.events
+        : [];
+
+    const events = (rawEvents as unknown[]).map((event: unknown) =>
+      normalizeEvent(event),
+    );
+    const nextCursor =
+      readString(payload?.nextCursor) ??
+      readString(payload?.next_cursor) ??
+      events.at(-1)?.cursor ??
+      params.cursor ??
+      null;
+
+    return {
+      events,
+      nextCursor,
+      source: this.endpoint,
+    };
+  }
+}
+
+export class BlockchainEventListenerService {
+  constructor(
+    private readonly repository: BlockchainEventListenerRepositoryLike = new BlockchainEventListenerRepository(),
+    private readonly source: BlockchainEventSource = new HttpBlockchainEventSource(),
+    private readonly streamName = "stellar-app-events",
+    private readonly batchSize = 50,
+  ) {}
+
+  async sync(): Promise<SyncSummary> {
+    const cursor = await this.repository.getCursor(this.streamName);
+    const retryableEvents = await this.repository.getRetryableEvents(this.batchSize);
+
+    let processed = 0;
+    let retried = 0;
+    let duplicates = 0;
+    let ignored = 0;
+    let failed = 0;
+
+    for (const event of retryableEvents) {
+      const outcome = await this.processEvent(event, event.source ?? "retry");
+      if (outcome === "processed") {
+        processed += 1;
+        retried += 1;
+      } else if (outcome === "duplicate") {
+        duplicates += 1;
+      } else if (outcome === "ignored") {
+        ignored += 1;
+      } else {
+        failed += 1;
+      }
+    }
+
+    const batch = await this.source.fetchEvents({
+      cursor,
+      limit: this.batchSize,
+    });
+
+    for (const event of batch.events) {
+      const outcome = await this.processEvent(event, batch.source ?? "stellar");
+      if (outcome === "processed") {
+        processed += 1;
+      } else if (outcome === "duplicate") {
+        duplicates += 1;
+      } else if (outcome === "ignored") {
+        ignored += 1;
+      } else {
+        failed += 1;
+      }
+    }
+
+    const nextCursor =
+      batch.nextCursor ??
+      batch.events.at(-1)?.cursor ??
+      cursor ??
+      null;
+
+    if (nextCursor && nextCursor !== cursor) {
+      await this.repository.saveCursor(this.streamName, nextCursor);
+    }
+
+    return {
+      cursor: nextCursor,
+      processed,
+      retried,
+      duplicates,
+      ignored,
+      failed,
+      fetched: batch.events.length,
+    };
+  }
+
+  private async processEvent(
+    event: BlockchainEvent,
+    source: string,
+  ): Promise<"processed" | "duplicate" | "ignored" | "failed"> {
+    const stored = await this.repository.upsertEventLog(event, source);
+
+    if (stored.status === "processed") {
+      return "duplicate";
+    }
+
+    if (stored.status === "ignored") {
+      return "ignored";
+    }
+
+    await this.repository.markProcessing(event.id);
+
+    try {
+      await this.applyEvent(event);
+      await this.repository.markProcessed(event.id);
+      return "processed";
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Unknown blockchain sync error";
+
+      if (error instanceof IgnoredEventError) {
+        await this.repository.markIgnored(event.id, message);
+        return "ignored";
+      }
+
+      if (error instanceof PermanentSyncError) {
+        await this.repository.markFailed(event.id, message);
+        return "failed";
+      }
+
+      await this.repository.markRetrying(event.id, message);
+      return "failed";
+    }
+  }
+
+  private async applyEvent(event: BlockchainEvent): Promise<void> {
+    switch (event.type) {
+      case "ownership.updated":
+      case "snippet.transferred":
+        await this.repository.syncSnippetOwnership({
+          snippetId: requireString(event.snippetId, "snippetId"),
+          newOwnerWalletAddress: requireString(
+            event.newOwnerWalletAddress,
+            "newOwnerWalletAddress",
+          ),
+          previousOwnerWalletAddress: event.previousOwnerWalletAddress ?? null,
+          txHash: event.txHash ?? null,
+          timestamp: event.timestamp,
+          metadata: event.metadata ?? null,
+        });
+        return;
+
+      case "verification.wallet":
+        await this.repository.upsertWalletVerification({
+          walletAddress: requireString(event.walletAddress, "walletAddress"),
+          txHash: event.txHash ?? null,
+          timestamp: event.timestamp,
+          metadata: event.metadata ?? null,
+        });
+        return;
+
+      case "verification.snippet":
+        await this.repository.recordSnippetVerification({
+          snippetId: requireString(event.snippetId, "snippetId"),
+          walletAddress: requireString(event.walletAddress, "walletAddress"),
+          signature: event.signature ?? null,
+          message: event.message ?? null,
+          txHash: event.txHash ?? null,
+          timestamp: event.timestamp,
+        });
+        return;
+
+      case "permission.granted":
+      case "permission.revoked":
+        await this.repository.syncPermission({
+          snippetId: requireString(event.snippetId, "snippetId"),
+          targetWalletAddress: requireString(
+            event.targetWalletAddress,
+            "targetWalletAddress",
+          ),
+          actorWalletAddress: requireString(
+            event.actorWalletAddress,
+            "actorWalletAddress",
+          ),
+          permissionType: requirePermissionType(event.permissionType),
+          active: event.type === "permission.granted",
+          txHash: event.txHash ?? null,
+          timestamp: event.timestamp,
+        });
+        return;
+
+      default:
+        throw new IgnoredEventError(`Unsupported event type: ${event.type}`);
+    }
+  }
+}
+
+function normalizeEvent(input: unknown): BlockchainEvent {
+  const record = isRecord(input) ? input : {};
+  const metadata = readRecord(record.metadata) ?? readRecord(record.payload) ?? null;
+
+  return {
+    id: readString(record.id) ?? hashEvent(record),
+    type: readString(record.type) ?? readString(record.eventType) ?? "unknown",
+    timestamp:
+      readString(record.timestamp) ??
+      readString(record.createdAt) ??
+      readString(record.created_at) ??
+      new Date().toISOString(),
+    cursor: readString(record.cursor) ?? readString(record.pagingToken) ?? null,
+    txHash:
+      readString(record.txHash) ??
+      readString(record.transactionHash) ??
+      readString(record.tx_hash) ??
+      null,
+    contractId: readString(record.contractId) ?? readString(record.contract_id) ?? null,
+    ledger: readNumber(record.ledger),
+    snippetId:
+      readString(record.snippetId) ??
+      readString(metadata?.snippetId) ??
+      readString(metadata?.snippet_id) ??
+      null,
+    walletAddress:
+      readString(record.walletAddress) ??
+      readString(metadata?.walletAddress) ??
+      readString(metadata?.wallet_address) ??
+      null,
+    previousOwnerWalletAddress:
+      readString(record.previousOwnerWalletAddress) ??
+      readString(metadata?.previousOwnerWalletAddress) ??
+      readString(metadata?.oldOwnerWalletAddress) ??
+      readString(metadata?.previous_owner_wallet_address) ??
+      null,
+    newOwnerWalletAddress:
+      readString(record.newOwnerWalletAddress) ??
+      readString(metadata?.newOwnerWalletAddress) ??
+      readString(metadata?.ownerWalletAddress) ??
+      readString(metadata?.new_owner_wallet_address) ??
+      null,
+    actorWalletAddress:
+      readString(record.actorWalletAddress) ??
+      readString(metadata?.actorWalletAddress) ??
+      readString(metadata?.grantedByWalletAddress) ??
+      readString(metadata?.actor_wallet_address) ??
+      null,
+    targetWalletAddress:
+      readString(record.targetWalletAddress) ??
+      readString(metadata?.targetWalletAddress) ??
+      readString(metadata?.granteeWalletAddress) ??
+      readString(metadata?.target_wallet_address) ??
+      null,
+    permissionType: normalizePermissionType(
+      readString(record.permissionType) ?? readString(metadata?.permissionType),
+    ),
+    signature:
+      readString(record.signature) ??
+      readString(metadata?.signature) ??
+      null,
+    message:
+      readString(record.message) ??
+      readString(metadata?.message) ??
+      null,
+    metadata,
+  };
+}
+
+function hashEvent(value: unknown): string {
+  return crypto.createHash("sha256").update(JSON.stringify(value)).digest("hex");
+}
+
+function requireString(
+  value: string | null | undefined,
+  fieldName: string,
+): string {
+  if (!value) {
+    throw new PermanentSyncError(`Missing required event field: ${fieldName}`);
+  }
+  return value;
+}
+
+function requirePermissionType(
+  value: PermissionType | null | undefined,
+): PermissionType {
+  if (!value) {
+    throw new PermanentSyncError("Missing required event field: permissionType");
+  }
+  return value;
+}
+
+function normalizePermissionType(value: string | null | undefined): PermissionType | null {
+  return value === "view" || value === "edit" ? value : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function readRecord(value: unknown): Record<string, unknown> | null {
+  return isRecord(value) ? value : null;
+}
+
+function readString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function readNumber(value: unknown): number | null {
+  return typeof value === "number" ? value : null;
+}

--- a/lib/blockchain-event-listener.types.ts
+++ b/lib/blockchain-event-listener.types.ts
@@ -1,0 +1,57 @@
+export type BlockchainEventType =
+  | "ownership.updated"
+  | "snippet.transferred"
+  | "verification.wallet"
+  | "verification.snippet"
+  | "permission.granted"
+  | "permission.revoked";
+
+export type EventLogStatus =
+  | "pending"
+  | "processing"
+  | "processed"
+  | "retrying"
+  | "failed"
+  | "ignored";
+
+export type PermissionType = "view" | "edit";
+
+export interface BlockchainEvent {
+  id: string;
+  type: string;
+  timestamp: string;
+  cursor?: string | null;
+  txHash?: string | null;
+  contractId?: string | null;
+  ledger?: number | null;
+  snippetId?: string | null;
+  walletAddress?: string | null;
+  previousOwnerWalletAddress?: string | null;
+  newOwnerWalletAddress?: string | null;
+  actorWalletAddress?: string | null;
+  targetWalletAddress?: string | null;
+  permissionType?: PermissionType | null;
+  signature?: string | null;
+  message?: string | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+export interface StoredBlockchainEvent extends BlockchainEvent {
+  status: EventLogStatus;
+  attempts: number;
+  source?: string | null;
+  lastError?: string | null;
+}
+
+export interface BlockchainEventBatch {
+  events: BlockchainEvent[];
+  nextCursor?: string | null;
+  source?: string | null;
+}
+
+export interface BlockchainEventSource {
+  fetchEvents(params: {
+    cursor?: string | null;
+    limit: number;
+  }): Promise<BlockchainEventBatch>;
+}

--- a/scripts/migrations/002_add_blockchain_event_listener.sql
+++ b/scripts/migrations/002_add_blockchain_event_listener.sql
@@ -1,0 +1,46 @@
+CREATE TABLE IF NOT EXISTS blockchain_event_cursors (
+  stream_name VARCHAR(100) PRIMARY KEY,
+  cursor TEXT NOT NULL,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS blockchain_event_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_id VARCHAR(255) NOT NULL UNIQUE,
+  event_type VARCHAR(100) NOT NULL,
+  cursor TEXT,
+  tx_hash VARCHAR(255),
+  contract_id VARCHAR(255),
+  source TEXT,
+  status VARCHAR(20) NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'processing', 'processed', 'retrying', 'failed', 'ignored')),
+  attempts INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  payload JSONB NOT NULL DEFAULT '{}'::jsonb,
+  processed_at TIMESTAMP,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS wallet_identity_verifications (
+  wallet_address VARCHAR(56) PRIMARY KEY,
+  status VARCHAR(20) NOT NULL DEFAULT 'verified'
+    CHECK (status IN ('verified', 'revoked')),
+  last_verified_at TIMESTAMP,
+  tx_hash VARCHAR(255),
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_blockchain_event_logs_status_updated
+  ON blockchain_event_logs(status, updated_at ASC);
+
+CREATE INDEX IF NOT EXISTS idx_blockchain_event_logs_tx_hash
+  ON blockchain_event_logs(tx_hash);
+
+CREATE INDEX IF NOT EXISTS idx_blockchain_event_logs_processed_at
+  ON blockchain_event_logs(processed_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_wallet_identity_verifications_verified_at
+  ON wallet_identity_verifications(last_verified_at DESC);

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/backup",
       "schedule": "0 0 * * *"
+    },
+    {
+      "path": "/api/cron/blockchain-events",
+      "schedule": "*/5 * * * *"
     }
   ]
 }


### PR DESCRIPTION
## Overview

This PR adds a **Blockchain Event Listener Service** for Stellar-related application events. It persists inbound blockchain events, prevents duplicate processing, retries transient sync failures, and reconciles ownership, transfer, verification, and permission changes with the platform database.

## Related Issue

Closes #136

## Changes

### Blockchain Event Listener

- **[ADD]** `lib/blockchain-event-listener.types.ts`
  - Defines normalized blockchain event types, statuses, and event-source contracts.

- **[ADD]** `lib/blockchain-event-listener.repository.ts`
  - Stores sync cursors and blockchain event audit logs.
  - Enforces exact-once processing with unique event IDs.
  - Synchronizes ownership, transfers, verification, and permission state with the database.

- **[ADD]** `lib/blockchain-event-listener.service.ts`
  - Polls a configured Stellar event source and replays retryable events before new events.
  - Marks unsupported events as ignored and malformed events as failed.
  - Retries transient failures for later reprocessing.

### Scheduling And Delivery

- **[ADD]** `app/api/cron/blockchain-events/route.ts`
  - Adds a protected cron endpoint that runs the blockchain sync service.

- **[ADD]** `scripts/migrations/002_add_blockchain_event_listener.sql`
  - Creates cursor, event log, retry, and wallet verification tables.

- **[MODIFY]** `vercel.json`
  - Schedules the blockchain sync cron every 5 minutes.

### Tests

- **[ADD]** `lib/blockchain-event-listener.service.test.ts`
  - Covers ownership sync, duplicate-event skipping, retry processing, and permanent failure handling.

## Verification Results

```bash
npx tsc --noEmit
npx jest lib/blockchain-event-listener.service.test.ts --env=node --runInBand --watchman=false
```

```text
PASS  lib/blockchain-event-listener.service.test.ts
  BlockchainEventListenerService
    ✓ processes ownership transfer events and saves the newest cursor
    ✓ skips events that were already processed
    ✓ retries transient failures from the retry queue before fetching new events
    ✓ marks malformed events as permanently failed
```

| Acceptance Criteria | Status |
|---|---|
| Reliable event listening | ✅ Added cron-driven listener service with persisted cursor tracking |
| Database synchronization | ✅ Syncs ownership, transfers, wallet verification, snippet verification, and permissions |
| No duplication | ✅ Unique event IDs and processed-state dedupe |
| Error resilience | ✅ Retry queue persists transient failures for later replay |
| Audit trail maintained | ✅ Event logs and activity records are stored for traceability |