### PR TITLE
feat: add drag-and-drop snippet folders

### DIFF
--- a/app/snippets/page.tsx
+++ b/app/snippets/page.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { FolderKanban, RefreshCw } from "lucide-react";
+import { Sidebar } from "@/components/Sidebar";
+import { SnippetFolderOrganizer } from "@/components/SnippetFolderOrganizer";
+
+interface SnippetSummary { id: string; title: string; language: string; }
+
+export default function SnippetsPage() {
+  const [snippets, setSnippets] = useState<SnippetSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  async function load() {
+    setLoading(true); setError("");
+    try {
+      const response = await fetch("/api/snippets?limit=100&offset=0");
+      if (!response.ok) throw new Error("Could not load snippets");
+      const result = await response.json();
+      setSnippets(Array.isArray(result) ? result : result.data || []);
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : "Could not load snippets");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => { void load(); }, []);
+  return (
+    <div className="flex min-h-screen bg-slate-950 text-slate-100">
+      <Sidebar />
+      <main className="min-w-0 flex-1 px-4 py-20 md:px-8 md:py-8">
+        <div className="mx-auto max-w-6xl">
+          <header className="mb-8">
+            <div className="mb-2 flex items-center gap-3"><div className="rounded-lg bg-fuchsia-500/15 p-2 text-fuchsia-300"><FolderKanban className="h-5 w-5" /></div><h1 className="text-2xl font-bold sm:text-3xl">Organize snippets</h1></div>
+            <p className="text-sm text-slate-400">Create folders and drag snippets to arrange your workspace. Changes are saved on this device.</p>
+          </header>
+          {loading && <p className="py-20 text-center text-slate-400">Loading snippets…</p>}
+          {error && <div className="rounded-xl border border-rose-500/30 bg-rose-500/10 p-5 text-rose-200">{error}<button className="ml-4 inline-flex items-center gap-1 underline" onClick={() => void load()}><RefreshCw className="h-3.5 w-3.5" />Retry</button></div>}
+          {!loading && !error && <SnippetFolderOrganizer snippets={snippets} />}
+        </div>
+      </main>
+    </div>
+  );
+}

--- a/components/SnippetFolderOrganizer.tsx
+++ b/components/SnippetFolderOrganizer.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { FileCode2, Folder, FolderPlus, GripVertical, Pencil, Trash2 } from "lucide-react";
+import {
+  addFolder,
+  createOrganization,
+  deleteFolder,
+  FOLDER_STORAGE_KEY,
+  FolderOrganization,
+  moveSnippet,
+  normalizeOrganization,
+  renameFolder,
+  reorderFolder,
+} from "@/lib/snippet-folders";
+
+interface SnippetSummary { id: string; title: string; language: string; }
+type DragItem = { type: "snippet"; id: string } | { type: "folder"; id: string };
+
+export function SnippetFolderOrganizer({ snippets }: { snippets: SnippetSummary[] }) {
+  const [organization, setOrganization] = useState<FolderOrganization>(() => createOrganization(snippets.map((item) => item.id)));
+  const [folderName, setFolderName] = useState("");
+  const [dragged, setDragged] = useState<DragItem | null>(null);
+  const [dropTarget, setDropTarget] = useState("");
+  const [ready, setReady] = useState(false);
+  const lookup = new Map(snippets.map((snippet) => [snippet.id, snippet]));
+
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(FOLDER_STORAGE_KEY);
+      setOrganization(normalizeOrganization(saved ? JSON.parse(saved) : null, snippets.map((item) => item.id)));
+    } catch {
+      setOrganization(createOrganization(snippets.map((item) => item.id)));
+    }
+    setReady(true);
+  }, [snippets]);
+
+  useEffect(() => {
+    if (ready) localStorage.setItem(FOLDER_STORAGE_KEY, JSON.stringify(organization));
+  }, [organization, ready]);
+
+  function createFolder() {
+    if (!folderName.trim()) return;
+    setOrganization((state) => addFolder(state, folderName, crypto.randomUUID()));
+    setFolderName("");
+  }
+
+  function dropSnippet(destinationId: string | null, index?: number) {
+    if (dragged?.type === "snippet") setOrganization((state) => moveSnippet(state, dragged.id, destinationId, index));
+    setDragged(null); setDropTarget("");
+  }
+
+  const snippetCard = (id: string, destinationId: string | null, index: number) => {
+    const snippet = lookup.get(id);
+    if (!snippet) return null;
+    return (
+      <article
+        key={id}
+        draggable
+        onDragStart={() => setDragged({ type: "snippet", id })}
+        onDragEnd={() => { setDragged(null); setDropTarget(""); }}
+        onDragOver={(event) => { event.preventDefault(); setDropTarget(`snippet:${destinationId ?? "unfiled"}:${index}`); }}
+        onDrop={(event) => { event.preventDefault(); dropSnippet(destinationId, index); }}
+        className={`group flex cursor-grab items-center gap-3 rounded-lg border bg-slate-900 p-3 transition active:cursor-grabbing ${
+          dropTarget === `snippet:${destinationId ?? "unfiled"}:${index}` ? "border-fuchsia-400 translate-y-1" : "border-white/10 hover:border-fuchsia-400/40"
+        }`}
+      >
+        <GripVertical className="h-4 w-4 text-slate-600 group-hover:text-fuchsia-300" />
+        <FileCode2 className="h-4 w-4 text-blue-300" />
+        <div className="min-w-0"><h3 className="truncate text-sm font-medium text-slate-100">{snippet.title}</h3><p className="text-xs text-slate-500">{snippet.language}</p></div>
+      </article>
+    );
+  };
+
+  const zone = (destinationId: string | null, ids: string[]) => (
+    <div
+      onDragOver={(event) => { event.preventDefault(); setDropTarget(`zone:${destinationId ?? "unfiled"}`); }}
+      onDrop={(event) => { event.preventDefault(); dropSnippet(destinationId); }}
+      className={`min-h-20 space-y-2 rounded-lg border border-dashed p-2 transition ${
+        dropTarget === `zone:${destinationId ?? "unfiled"}` ? "border-fuchsia-400 bg-fuchsia-500/10" : "border-white/10"
+      }`}
+    >
+      {ids.length ? ids.map((id, index) => snippetCard(id, destinationId, index)) : <p className="py-5 text-center text-xs text-slate-600">Drop snippets here</p>}
+    </div>
+  );
+
+  return (
+    <div>
+      <form className="mb-8 flex max-w-xl gap-2" onSubmit={(event) => { event.preventDefault(); createFolder(); }}>
+        <label className="sr-only" htmlFor="folder-name">Folder name</label>
+        <input id="folder-name" value={folderName} onChange={(event) => setFolderName(event.target.value)} placeholder="New folder name" maxLength={60} className="min-w-0 flex-1 rounded-lg border border-white/10 bg-slate-900 px-4 py-2.5 outline-none focus:border-fuchsia-400" />
+        <button className="inline-flex items-center gap-2 rounded-lg bg-fuchsia-600 px-4 py-2.5 font-medium transition hover:bg-fuchsia-500" type="submit"><FolderPlus className="h-4 w-4" />Create</button>
+      </form>
+
+      <section className="mb-8">
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-slate-400">Unfiled snippets <span className="ml-1 text-slate-600">{organization.unfiledSnippetIds.length}</span></h2>
+        {zone(null, organization.unfiledSnippetIds)}
+      </section>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {organization.folderOrder.map((id, index) => {
+          const folder = organization.folders[id];
+          return (
+            <section
+              key={id}
+              draggable
+              onDragStart={(event) => { if ((event.target as HTMLElement).closest("article")) { event.preventDefault(); return; } setDragged({ type: "folder", id }); }}
+              onDragOver={(event) => { if (dragged?.type === "folder") { event.preventDefault(); setDropTarget(`folder:${index}`); } }}
+              onDrop={(event) => { if (dragged?.type === "folder") { event.preventDefault(); setOrganization((state) => reorderFolder(state, dragged.id, index)); setDragged(null); setDropTarget(""); } }}
+              className={`rounded-xl border bg-white/[.03] p-4 transition ${dropTarget === `folder:${index}` ? "border-fuchsia-400 ring-2 ring-fuchsia-400/20" : "border-white/10"}`}
+            >
+              <header className="mb-3 flex items-center gap-2">
+                <GripVertical className="h-4 w-4 cursor-grab text-slate-600" />
+                <Folder className="h-4 w-4 text-amber-300" />
+                <h2 className="min-w-0 flex-1 truncate font-semibold">{folder.name}</h2>
+                <span className="text-xs text-slate-500">{folder.snippetIds.length}</span>
+                <button aria-label={`Rename ${folder.name}`} className="p-1.5 text-slate-500 hover:text-fuchsia-300" onClick={() => { const name = window.prompt("Rename folder", folder.name); if (name) setOrganization((state) => renameFolder(state, id, name)); }}><Pencil className="h-3.5 w-3.5" /></button>
+                <button aria-label={`Delete ${folder.name}`} className="p-1.5 text-slate-500 hover:text-rose-300" onClick={() => { if (window.confirm(`Delete “${folder.name}”? Its snippets will become unfiled.`)) setOrganization((state) => deleteFolder(state, id)); }}><Trash2 className="h-3.5 w-3.5" /></button>
+              </header>
+              {zone(id, folder.snippetIds)}
+            </section>
+          );
+        })}
+      </div>
+      {organization.folderOrder.length === 0 && <p className="rounded-xl border border-dashed border-white/10 py-12 text-center text-sm text-slate-500">Create a folder, then drag snippets into it.</p>}
+    </div>
+  );
+}

--- a/lib/snippet-folders.test.ts
+++ b/lib/snippet-folders.test.ts
@@ -1,0 +1,31 @@
+import { addFolder, createOrganization, deleteFolder, moveSnippet, normalizeOrganization, renameFolder, reorderFolder } from "./snippet-folders";
+
+describe("snippet folder organization", () => {
+  it("creates, renames, reorders, and deletes folders without losing snippets", () => {
+    let state = createOrganization(["a", "b"]);
+    state = addFolder(state, "Backend", "folder-1");
+    state = addFolder(state, "Frontend", "folder-2");
+    state = renameFolder(state, "folder-1", "API");
+    state = moveSnippet(state, "a", "folder-1");
+    state = reorderFolder(state, "folder-2", 0);
+    expect(state.folderOrder).toEqual(["folder-2", "folder-1"]);
+    expect(state.folders["folder-1"]).toMatchObject({ name: "API", snippetIds: ["a"] });
+    state = deleteFolder(state, "folder-1");
+    expect(state.unfiledSnippetIds).toContain("a");
+  });
+
+  it("moves and reorders snippets between folders", () => {
+    let state = addFolder(createOrganization(["a", "b", "c"]), "Work", "work");
+    state = moveSnippet(state, "a", "work");
+    state = moveSnippet(state, "b", "work");
+    state = moveSnippet(state, "b", "work", 0);
+    expect(state.folders.work.snippetIds).toEqual(["b", "a"]);
+  });
+
+  it("restores valid state while adding newly discovered snippets", () => {
+    const saved = moveSnippet(addFolder(createOrganization(["a"]), "Work", "work"), "a", "work");
+    const restored = normalizeOrganization(saved, ["a", "new"]);
+    expect(restored.folders.work.snippetIds).toEqual(["a"]);
+    expect(restored.unfiledSnippetIds).toEqual(["new"]);
+  });
+});

--- a/lib/snippet-folders.ts
+++ b/lib/snippet-folders.ts
@@ -1,0 +1,98 @@
+export const FOLDER_STORAGE_KEY = "codely:snippet-folders:v1";
+
+export interface SnippetFolder {
+  id: string;
+  name: string;
+  snippetIds: string[];
+}
+
+export interface FolderOrganization {
+  version: 1;
+  folderOrder: string[];
+  folders: Record<string, SnippetFolder>;
+  unfiledSnippetIds: string[];
+}
+
+export function createOrganization(snippetIds: string[]): FolderOrganization {
+  return { version: 1, folderOrder: [], folders: {}, unfiledSnippetIds: [...snippetIds] };
+}
+
+export function normalizeOrganization(value: unknown, snippetIds: string[]): FolderOrganization {
+  const fallback = createOrganization(snippetIds);
+  if (!value || typeof value !== "object") return fallback;
+  const candidate = value as Partial<FolderOrganization>;
+  if (candidate.version !== 1 || !candidate.folders || !Array.isArray(candidate.folderOrder)) return fallback;
+
+  const valid = new Set(snippetIds);
+  const used = new Set<string>();
+  const folders: Record<string, SnippetFolder> = {};
+  const folderOrder = candidate.folderOrder.filter((id) => {
+    const folder = candidate.folders?.[id];
+    if (!folder || typeof folder.name !== "string" || !Array.isArray(folder.snippetIds)) return false;
+    folders[id] = {
+      id,
+      name: folder.name,
+      snippetIds: folder.snippetIds.filter((snippetId) => valid.has(snippetId) && !used.has(snippetId) && used.add(snippetId)),
+    };
+    return true;
+  });
+  const savedUnfiled = Array.isArray(candidate.unfiledSnippetIds) ? candidate.unfiledSnippetIds : [];
+  const unfiledSnippetIds = [
+    ...savedUnfiled.filter((id) => valid.has(id) && !used.has(id) && used.add(id)),
+    ...snippetIds.filter((id) => !used.has(id)),
+  ];
+  return { version: 1, folderOrder, folders, unfiledSnippetIds };
+}
+
+export function addFolder(state: FolderOrganization, name: string, id: string): FolderOrganization {
+  const trimmed = name.trim();
+  if (!trimmed) return state;
+  return {
+    ...state,
+    folderOrder: [...state.folderOrder, id],
+    folders: { ...state.folders, [id]: { id, name: trimmed, snippetIds: [] } },
+  };
+}
+
+export function renameFolder(state: FolderOrganization, id: string, name: string): FolderOrganization {
+  const trimmed = name.trim();
+  if (!state.folders[id] || !trimmed) return state;
+  return { ...state, folders: { ...state.folders, [id]: { ...state.folders[id], name: trimmed } } };
+}
+
+export function deleteFolder(state: FolderOrganization, id: string): FolderOrganization {
+  const folder = state.folders[id];
+  if (!folder) return state;
+  const folders = { ...state.folders };
+  delete folders[id];
+  return {
+    ...state,
+    folders,
+    folderOrder: state.folderOrder.filter((folderId) => folderId !== id),
+    unfiledSnippetIds: [...state.unfiledSnippetIds, ...folder.snippetIds],
+  };
+}
+
+export function moveSnippet(
+  state: FolderOrganization,
+  snippetId: string,
+  destinationId: string | null,
+  destinationIndex?: number,
+): FolderOrganization {
+  const folders = Object.fromEntries(Object.entries(state.folders).map(([id, folder]) => [
+    id, { ...folder, snippetIds: folder.snippetIds.filter((value) => value !== snippetId) },
+  ]));
+  let unfiledSnippetIds = state.unfiledSnippetIds.filter((value) => value !== snippetId);
+  const destination = destinationId ? folders[destinationId]?.snippetIds : unfiledSnippetIds;
+  if (!destination) return state;
+  const index = Math.max(0, Math.min(destinationIndex ?? destination.length, destination.length));
+  destination.splice(index, 0, snippetId);
+  if (!destinationId) unfiledSnippetIds = destination;
+  return { ...state, folders, unfiledSnippetIds };
+}
+
+export function reorderFolder(state: FolderOrganization, folderId: string, destinationIndex: number) {
+  const order = state.folderOrder.filter((id) => id !== folderId);
+  order.splice(Math.max(0, Math.min(destinationIndex, order.length)), 0, folderId);
+  return { ...state, folderOrder: order };
+}


### PR DESCRIPTION
## Summary
- add folder creation, rename, and deletion to the snippets workspace
- support native drag-and-drop for moving/reordering snippets and reordering folders
- provide clear active drop zones, hover states, empty states, and keyboard-accessible management controls
- persist versioned organization state in local storage and reconcile it with current snippets
- add focused tests for folder lifecycle, moves, ordering, deletion, and restoration

Closes #126

## Validation
- git diff --check ✅
- strict TypeScript check for lib/snippet-folders.ts ✅
- isolated behavioral smoke tests for folder state transitions ✅
- 
pm test, 
pm run lint, and 
pm run build could not run from a clean install because both committed lockfiles are out of sync with package.json; direct repository TypeScript validation additionally reports pre-existing syntax errors in pp/api/snippets/snippet.service.ts and components/WalletConnect.tsx. No unrelated files were changed.