### PR TITLE
feat: implement wallet-based snippet sharing permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# test coverage
+coverage

--- a/app/api/snippets/[id]/permissions/route.test.ts
+++ b/app/api/snippets/[id]/permissions/route.test.ts
@@ -1,0 +1,301 @@
+jest.mock("next/server", () => ({
+  NextRequest: class MockNextRequest {
+    public headers: Headers;
+    private _body: any;
+    public url: string;
+
+    constructor(input: string | URL, init?: RequestInit & { headers: Headers }) {
+      this.url = typeof input === "string" ? input : input.toString();
+      this.headers = init?.headers ?? new Headers();
+      this._body = init?.body ? JSON.parse(init.body as string) : null;
+    }
+
+    async json() {
+      return this._body;
+    }
+  },
+  NextResponse: {
+    json: (body: any, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+      headers: new Headers({ "content-type": "application/json" }),
+    }),
+  },
+}));
+
+jest.mock("@/lib/permissions.service", () => ({
+  grant: jest.fn(),
+  revoke: jest.fn(),
+  getPermissionsForSnippet: jest.fn(),
+  getActivityLog: jest.fn(),
+}));
+
+jest.mock("../../ownership.middleware", () => ({
+  OwnershipMiddleware: {
+    extractWalletAddress: jest.fn(),
+  },
+}));
+
+import { NextRequest } from "next/server";
+
+import { GET, POST, DELETE } from "./route";
+import * as permissionsService from "@/lib/permissions.service";
+import { OwnershipMiddleware } from "../../ownership.middleware";
+
+const SNIPPET_ID = "550e8400-e29b-41d4-a716-446655440000";
+const WALLET = "GBRRHRH76DXEKWF3SCDYH7G7M4G3E4DEBIY7WBHBMRGBENRGQWSDLV2V";
+const GRANTEE = "GDTNW5S3JSV27YLRU5XXXHXWLKATYO5ZJABA7QUITDO2YMFU5UXXKQRH";
+const VALID_STELLAR = "GCRKPWEEZPKBMQ7L3FAKKZL7TPJBKEHIWUBMN554ASGZKDJXJ7FCXRRU";
+const SHORT_ADDR = "GABCDEF";
+const BAD_PREFIX = "A" + "X".repeat(55);
+const INVALID_CHARS = "G" + "0".repeat(55);
+
+function makeRequest(overrides: {
+  method?: string;
+  body?: unknown;
+  wallet?: string | null;
+  searchParams?: string;
+} = {}): NextRequest {
+  const headers = new Headers({ "Content-Type": "application/json" });
+  if (overrides.wallet) {
+    headers.set("x-wallet-address", overrides.wallet);
+  }
+  const init: any = { method: overrides.method ?? "GET", headers };
+  if (overrides.body !== undefined) {
+    init.body = JSON.stringify(overrides.body);
+  }
+  return new (NextRequest as any)("http://localhost:3000/api/snippets/" + SNIPPET_ID + "/permissions" + (overrides.searchParams ? "?" + overrides.searchParams : ""), init);
+}
+
+let consoleSpy: jest.SpyInstance;
+beforeAll(() => {
+  consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+});
+afterAll(() => {
+  consoleSpy.mockRestore();
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("GET /api/snippets/[id]/permissions", () => {
+  it("returns 401 when no wallet address is provided", async () => {
+    (OwnershipMiddleware.extractWalletAddress as jest.Mock).mockResolvedValue(null);
+
+    const req = makeRequest({ wallet: null });
+    const params = Promise.resolve({ id: SNIPPET_ID });
+    const res = await GET(req, { params });
+
+    expect(res.status).toBe(401);
+    const json = await res.json();
+    expect(json.error).toBe("Unauthorized");
+  });
+
+  it("returns permissions and optionally activity log", async () => {
+    (OwnershipMiddleware.extractWalletAddress as jest.Mock).mockResolvedValue(WALLET);
+    const mockPermissions = [
+      { id: "perm-1", grantee_wallet_address: GRANTEE, permission_type: "view" },
+    ];
+    (permissionsService.getPermissionsForSnippet as jest.Mock).mockResolvedValue(mockPermissions);
+    (permissionsService.getActivityLog as jest.Mock).mockResolvedValue([]);
+
+    const req = makeRequest({ wallet: WALLET, searchParams: "includeLog=true" });
+    const params = Promise.resolve({ id: SNIPPET_ID });
+    const res = await GET(req, { params });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.permissions).toEqual(mockPermissions);
+    expect(json.activityLog).toEqual([]);
+    expect(permissionsService.getActivityLog).toHaveBeenCalledWith(SNIPPET_ID);
+  });
+
+  it("skips activity log when includeLog is not true", async () => {
+    (OwnershipMiddleware.extractWalletAddress as jest.Mock).mockResolvedValue(WALLET);
+    (permissionsService.getPermissionsForSnippet as jest.Mock).mockResolvedValue([]);
+
+    const req = makeRequest({ wallet: WALLET });
+    const params = Promise.resolve({ id: SNIPPET_ID });
+    const res = await GET(req, { params });
+
+    expect(res.status).toBe(200);
+    expect(permissionsService.getActivityLog).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when the service throws", async () => {
+    (OwnershipMiddleware.extractWalletAddress as jest.Mock).mockResolvedValue(WALLET);
+    (permissionsService.getPermissionsForSnippet as jest.Mock).mockRejectedValue(new Error("DB error"));
+
+    const req = makeRequest({ wallet: WALLET });
+    const params = Promise.resolve({ id: SNIPPET_ID });
+    const res = await GET(req, { params });
+
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("Failed to fetch permissions");
+  });
+});
+
+describe("POST /api/snippets/[id]/permissions", () => {
+  it("returns 401 when no wallet address is provided", async () => {
+    (OwnershipMiddleware.extractWalletAddress as jest.Mock).mockResolvedValue(null);
+
+    const req = makeRequest({ method: "POST", wallet: null, body: { granteeWalletAddress: GRANTEE, permissionType: "view" } });
+    const params = Promise.resolve({ id: SNIPPET_ID });
+    const res = await POST(req, { params });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when the grantee address is too short", async () => {
+    (OwnershipMiddleware.extractWalletAddress as jest.Mock).mockResolvedValue(WALLET);
+
+    const req = makeRequest({ method: "POST", wallet: WALLET, body: { granteeWalletAddress: SHORT_ADDR, permissionType: "view" } });
+    const params = Promise.resolve({ id: SNIPPET_ID });
+    const res = await POST(req, { params });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Validation failed");
+  });
+
+  it("returns 400 when the grantee address does not start with G", async () => {
+    (OwnershipMiddleware.extractWalletAddress as jest.Mock).mockResolvedValue(WALLET);
+
+    const req = makeRequest({ method: "POST", wallet: WALLET, body: { granteeWalletAddress: BAD_PREFIX, permissionType: "view" } });
+    const params = Promise.resolve({ id: SNIPPET_ID });
+    const res = await POST(req, { params });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Validation failed");
+  });
+
+  it("returns 400 when the grantee address contains invalid characters", async () => {
+    (OwnershipMiddleware.extractWalletAddress as jest.Mock).mockResolvedValue(WALLET);
+
+    const req = makeRequest({ method: "POST", wallet: WALLET, body: { granteeWalletAddress: INVALID_CHARS, permissionType: "view" } });
+    const params = Promise.resolve({ id: SNIPPET_ID });
+    const res = await POST(req, { params });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Validation failed");
+  });
+
+  it("returns 400 when permission type is invalid", async () => {
+    (OwnershipMiddleware.extractWalletAddress as jest.Mock).mockResolvedValue(WALLET);
+
+    const req = makeRequest({ method: "POST", wallet: WALLET, body: { granteeWalletAddress: VALID_STELLAR, permissionType: "admin" } });
+    const params = Promise.resolve({ id: SNIPPET_ID });
+    const res = await POST(req, { params });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 201 on successful grant", async () => {
+    (OwnershipMiddleware.extractWalletAddress as jest.Mock).mockResolvedValue(WALLET);
+    const mockPermission = { id: "perm-1", snippet_id: SNIPPET_ID, grantee_wallet_address: VALID_STELLAR, permission_type: "view" };
+    (permissionsService.grant as jest.Mock).mockResolvedValue({ success: true, permission: mockPermission });
+
+    const req = makeRequest({ method: "POST", wallet: WALLET, body: { granteeWalletAddress: VALID_STELLAR, permissionType: "view" } });
+    const params = Promise.resolve({ id: SNIPPET_ID });
+    const res = await POST(req, { params });
+
+    expect(res.status).toBe(201);
+    const json = await res.json();
+    expect(json.id).toBe("perm-1");
+    expect(permissionsService.grant).toHaveBeenCalledWith(SNIPPET_ID, VALID_STELLAR, "view", WALLET);
+  });
+
+  it("returns 403 when the service returns an error", async () => {
+    (OwnershipMiddleware.extractWalletAddress as jest.Mock).mockResolvedValue(WALLET);
+    (permissionsService.grant as jest.Mock).mockResolvedValue({ success: false, error: "Only the snippet owner can grant permissions" });
+
+    const req = makeRequest({ method: "POST", wallet: WALLET, body: { granteeWalletAddress: VALID_STELLAR, permissionType: "view" } });
+    const params = Promise.resolve({ id: SNIPPET_ID });
+    const res = await POST(req, { params });
+
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toBe("Only the snippet owner can grant permissions");
+  });
+
+  it("returns 500 when service throws unexpectedly", async () => {
+    (OwnershipMiddleware.extractWalletAddress as jest.Mock).mockResolvedValue(WALLET);
+    (permissionsService.grant as jest.Mock).mockRejectedValue(new Error("Unexpected"));
+
+    const req = makeRequest({ method: "POST", wallet: WALLET, body: { granteeWalletAddress: VALID_STELLAR, permissionType: "view" } });
+    const params = Promise.resolve({ id: SNIPPET_ID });
+    const res = await POST(req, { params });
+
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("Failed to grant permission");
+  });
+});
+
+describe("DELETE /api/snippets/[id]/permissions", () => {
+  it("returns 401 when no wallet address is provided", async () => {
+    (OwnershipMiddleware.extractWalletAddress as jest.Mock).mockResolvedValue(null);
+
+    const req = makeRequest({ method: "DELETE", wallet: null, body: { granteeWalletAddress: GRANTEE, permissionType: "view" } });
+    const params = Promise.resolve({ id: SNIPPET_ID });
+    const res = await DELETE(req, { params });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when the wallet address is invalid format", async () => {
+    (OwnershipMiddleware.extractWalletAddress as jest.Mock).mockResolvedValue(WALLET);
+
+    const req = makeRequest({ method: "DELETE", wallet: WALLET, body: { granteeWalletAddress: "invalid", permissionType: "view" } });
+    const params = Promise.resolve({ id: SNIPPET_ID });
+    const res = await DELETE(req, { params });
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Validation failed");
+  });
+
+  it("returns 200 on successful revoke", async () => {
+    (OwnershipMiddleware.extractWalletAddress as jest.Mock).mockResolvedValue(WALLET);
+    (permissionsService.revoke as jest.Mock).mockResolvedValue({ success: true });
+
+    const req = makeRequest({ method: "DELETE", wallet: WALLET, body: { granteeWalletAddress: VALID_STELLAR, permissionType: "edit" } });
+    const params = Promise.resolve({ id: SNIPPET_ID });
+    const res = await DELETE(req, { params });
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.message).toBe("Permission revoked");
+    expect(permissionsService.revoke).toHaveBeenCalledWith(SNIPPET_ID, VALID_STELLAR, "edit", WALLET);
+  });
+
+  it("returns 403 when the service returns an error", async () => {
+    (OwnershipMiddleware.extractWalletAddress as jest.Mock).mockResolvedValue(WALLET);
+    (permissionsService.revoke as jest.Mock).mockResolvedValue({ success: false, error: "Permission not found or already revoked" });
+
+    const req = makeRequest({ method: "DELETE", wallet: WALLET, body: { granteeWalletAddress: VALID_STELLAR, permissionType: "view" } });
+    const params = Promise.resolve({ id: SNIPPET_ID });
+    const res = await DELETE(req, { params });
+
+    expect(res.status).toBe(403);
+    const json = await res.json();
+    expect(json.error).toBe("Permission not found or already revoked");
+  });
+
+  it("returns 500 when service throws unexpectedly", async () => {
+    (OwnershipMiddleware.extractWalletAddress as jest.Mock).mockResolvedValue(WALLET);
+    (permissionsService.revoke as jest.Mock).mockRejectedValue(new Error("Unexpected"));
+
+    const req = makeRequest({ method: "DELETE", wallet: WALLET, body: { granteeWalletAddress: VALID_STELLAR, permissionType: "view" } });
+    const params = Promise.resolve({ id: SNIPPET_ID });
+    const res = await DELETE(req, { params });
+
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("Failed to revoke permission");
+  });
+});

--- a/app/api/snippets/[id]/permissions/route.ts
+++ b/app/api/snippets/[id]/permissions/route.ts
@@ -8,16 +8,19 @@ import {
 } from "@/lib/permissions.service";
 import { z } from "zod";
 
+const stellarAddressRegex = /^G[A-Z2-7]{55}$/;
+
 const grantSchema = z.object({
   granteeWalletAddress: z
     .string()
-    .min(56, "Invalid Stellar wallet address")
-    .max(56, "Invalid Stellar wallet address"),
+    .regex(stellarAddressRegex, "Wallet address must be a valid Stellar format (starts with G, 56 characters)"),
   permissionType: z.enum(["view", "edit"]),
 });
 
 const revokeSchema = z.object({
-  granteeWalletAddress: z.string().min(56).max(56),
+  granteeWalletAddress: z
+    .string()
+    .regex(stellarAddressRegex, "Wallet address must be a valid Stellar format (starts with G, 56 characters)"),
   permissionType: z.enum(["view", "edit"]),
 });
 

--- a/lib/permissions.service.test.ts
+++ b/lib/permissions.service.test.ts
@@ -1,0 +1,235 @@
+jest.mock("@neondatabase/serverless", () => {
+  const mockSql = jest.fn().mockResolvedValue([]);
+  return { neon: jest.fn(() => mockSql) };
+});
+
+jest.mock("./permissions.repository", () => ({
+  grantPermission: jest.fn(),
+  revokePermission: jest.fn(),
+  getPermissionsForSnippet: jest.fn(),
+  getPermissionForWallet: jest.fn(),
+  hasPermission: jest.fn(),
+  getActivityLog: jest.fn(),
+}));
+
+import { neon } from "@neondatabase/serverless";
+import {
+  canView,
+  canEdit,
+  grant,
+  revoke,
+  getPermissionsForSnippet,
+  getActivityLog,
+} from "./permissions.service";
+import * as repo from "./permissions.repository";
+
+const SNIPPET_ID = "snippet-1";
+const OWNER = "GBRRHRH76DXEKWF3SCDYH7G7M4G3E4DEBIY7WBHBMRGBENRGQWSDLV2V";
+const GRANTEE = "GDTNW5S3JSV27YLRU5XXXHXWLKATYO5ZJABA7QUITDO2YMFU5UXXKQRH";
+const OTHER = "GCRKPWEEZPKBMQ7L3FAKKZL7TPJBKEHIWUBMN554ASGZKDJXJ7FCXRRU";
+
+let consoleSpy: jest.SpyInstance;
+let mockSql: jest.Mock;
+
+beforeAll(() => {
+  consoleSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+});
+afterAll(() => {
+  consoleSpy.mockRestore();
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSql = (neon as jest.Mock)() as jest.Mock;
+  mockSql.mockResolvedValue([]);
+});
+
+describe("Permissions Service", () => {
+  describe("canView", () => {
+    it("returns true when the caller is the snippet owner", async () => {
+      mockSql.mockResolvedValue([{ owner_wallet_address: OWNER }]);
+
+      const result = await canView(SNIPPET_ID, OWNER);
+
+      expect(result).toBe(true);
+      expect(repo.hasPermission).not.toHaveBeenCalled();
+    });
+
+    it("returns true when the caller has a direct view permission", async () => {
+      mockSql.mockResolvedValue([{ owner_wallet_address: OWNER }]);
+      (repo.hasPermission as jest.Mock).mockResolvedValueOnce(true);
+      (repo.hasPermission as jest.Mock).mockResolvedValueOnce(false);
+
+      const result = await canView(SNIPPET_ID, GRANTEE);
+
+      expect(result).toBe(true);
+      expect(repo.hasPermission).toHaveBeenCalledWith(SNIPPET_ID, GRANTEE, "view");
+      expect(repo.hasPermission).toHaveBeenCalledWith(SNIPPET_ID, GRANTEE, "edit");
+    });
+
+    it("returns true when the caller has an edit permission (edit implies view)", async () => {
+      mockSql.mockResolvedValue([{ owner_wallet_address: OWNER }]);
+      (repo.hasPermission as jest.Mock).mockResolvedValueOnce(false);
+      (repo.hasPermission as jest.Mock).mockResolvedValueOnce(true);
+
+      const result = await canView(SNIPPET_ID, GRANTEE);
+
+      expect(result).toBe(true);
+    });
+
+    it("returns false when the caller has no permission", async () => {
+      mockSql.mockResolvedValue([{ owner_wallet_address: OWNER }]);
+      (repo.hasPermission as jest.Mock).mockResolvedValue(false);
+
+      const result = await canView(SNIPPET_ID, OTHER);
+
+      expect(result).toBe(false);
+    });
+
+    it("returns false when the snippet does not exist", async () => {
+      mockSql.mockResolvedValue([]);
+
+      const result = await canView("non-existent", GRANTEE);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("canEdit", () => {
+    it("returns true when the caller is the snippet owner", async () => {
+      mockSql.mockResolvedValue([{ owner_wallet_address: OWNER }]);
+
+      const result = await canEdit(SNIPPET_ID, OWNER);
+
+      expect(result).toBe(true);
+      expect(repo.hasPermission).not.toHaveBeenCalled();
+    });
+
+    it("returns true when the caller has an edit permission", async () => {
+      mockSql.mockResolvedValue([{ owner_wallet_address: OWNER }]);
+      (repo.hasPermission as jest.Mock).mockResolvedValue(true);
+
+      const result = await canEdit(SNIPPET_ID, GRANTEE);
+
+      expect(result).toBe(true);
+      expect(repo.hasPermission).toHaveBeenCalledWith(SNIPPET_ID, GRANTEE, "edit");
+    });
+
+    it("returns false when the caller has only view permission", async () => {
+      mockSql.mockResolvedValue([{ owner_wallet_address: OWNER }]);
+      (repo.hasPermission as jest.Mock).mockResolvedValue(false);
+
+      const result = await canEdit(SNIPPET_ID, GRANTEE);
+
+      expect(result).toBe(false);
+    });
+
+    it("returns false when the snippet does not exist", async () => {
+      mockSql.mockResolvedValue([]);
+
+      const result = await canEdit("non-existent", GRANTEE);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("grant", () => {
+    it("grants view permission when the grantor is the owner", async () => {
+      mockSql.mockResolvedValue([{ owner_wallet_address: OWNER }]);
+      const expected = { id: "perm-1", snippet_id: SNIPPET_ID };
+      (repo.grantPermission as jest.Mock).mockResolvedValue(expected);
+
+      const result = await grant(SNIPPET_ID, GRANTEE, "view", OWNER);
+
+      expect(result).toEqual({ success: true, permission: expected });
+      expect(repo.grantPermission).toHaveBeenCalledWith(SNIPPET_ID, GRANTEE, "view", OWNER);
+    });
+
+    it("grants edit permission when the grantor is the owner", async () => {
+      mockSql.mockResolvedValue([{ owner_wallet_address: OWNER }]);
+      const expected = { id: "perm-2", snippet_id: SNIPPET_ID };
+      (repo.grantPermission as jest.Mock).mockResolvedValue(expected);
+
+      const result = await grant(SNIPPET_ID, GRANTEE, "edit", OWNER);
+
+      expect(result).toEqual({ success: true, permission: expected });
+      expect(repo.grantPermission).toHaveBeenCalledWith(SNIPPET_ID, GRANTEE, "edit", OWNER);
+    });
+
+    it("rejects grant when the snippet does not exist", async () => {
+      mockSql.mockResolvedValue([]);
+
+      const result = await grant("non-existent", GRANTEE, "view", OWNER);
+
+      expect(result).toEqual({ success: false, error: "Snippet not found" });
+      expect(repo.grantPermission).not.toHaveBeenCalled();
+    });
+
+    it("rejects grant when the grantor is not the owner", async () => {
+      mockSql.mockResolvedValue([{ owner_wallet_address: OWNER }]);
+
+      const result = await grant(SNIPPET_ID, GRANTEE, "view", OTHER);
+
+      expect(result).toEqual({ success: false, error: "Only the snippet owner can grant permissions" });
+      expect(repo.grantPermission).not.toHaveBeenCalled();
+    });
+
+    it("rejects grant when the grantee is the owner themselves", async () => {
+      mockSql.mockResolvedValue([{ owner_wallet_address: OWNER }]);
+
+      const result = await grant(SNIPPET_ID, OWNER, "view", OWNER);
+
+      expect(result).toEqual({ success: false, error: "Owner already has full access" });
+      expect(repo.grantPermission).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("revoke", () => {
+    it("revokes permission when the revoker is the owner", async () => {
+      mockSql.mockResolvedValue([{ owner_wallet_address: OWNER }]);
+      (repo.revokePermission as jest.Mock).mockResolvedValue(true);
+
+      const result = await revoke(SNIPPET_ID, GRANTEE, "view", OWNER);
+
+      expect(result).toEqual({ success: true });
+      expect(repo.revokePermission).toHaveBeenCalledWith(SNIPPET_ID, GRANTEE, "view", OWNER);
+    });
+
+    it("rejects revoke when the snippet does not exist", async () => {
+      mockSql.mockResolvedValue([]);
+
+      const result = await revoke("non-existent", GRANTEE, "view", OWNER);
+
+      expect(result).toEqual({ success: false, error: "Snippet not found" });
+      expect(repo.revokePermission).not.toHaveBeenCalled();
+    });
+
+    it("rejects revoke when the revoker is not the owner", async () => {
+      mockSql.mockResolvedValue([{ owner_wallet_address: OWNER }]);
+
+      const result = await revoke(SNIPPET_ID, GRANTEE, "view", OTHER);
+
+      expect(result).toEqual({ success: false, error: "Only the snippet owner can revoke permissions" });
+      expect(repo.revokePermission).not.toHaveBeenCalled();
+    });
+
+    it("returns error when the permission does not exist or is already revoked", async () => {
+      mockSql.mockResolvedValue([{ owner_wallet_address: OWNER }]);
+      (repo.revokePermission as jest.Mock).mockResolvedValue(false);
+
+      const result = await revoke(SNIPPET_ID, GRANTEE, "view", OWNER);
+
+      expect(result).toEqual({ success: false, error: "Permission not found or already revoked" });
+    });
+  });
+
+  describe("re-exports", () => {
+    it("re-exports getPermissionsForSnippet from the repository", () => {
+      expect(getPermissionsForSnippet).toBe(repo.getPermissionsForSnippet);
+    });
+
+    it("re-exports getActivityLog from the repository", () => {
+      expect(getActivityLog).toBe(repo.getActivityLog);
+    });
+  });
+});


### PR DESCRIPTION
Closes #135 

Enable snippet owners to grant viewing or editing permissions to specific Stellar wallet addresses. Permission data is validated with strict Stellar address format checks, stored securely with on-chain anchoring, and managed through a clear API + UI.

## What Changed

- **`app/api/snippets/[id]/permissions/route.ts`** — Added proper Stellar address validation (`/^G[A-Z2-7]{55}$/`) to both grant and revoke schemas (previously only checked string length)
- **`lib/permissions.service.test.ts`** — Comprehensive unit tests for `canView`, `canEdit`, `grant`, `revoke`, covering success paths, ownership checks, non-existent snippets, self-grant rejection, and already-revoked errors (20 tests)
- **`app/api/snippets/[id]/permissions/route.test.ts`** — API route tests for GET/POST/DELETE covering authentication (401), validation (400), authorization (403), success (200/201), and server errors (500) — 17 tests
- **`.gitignore`** — Added `coverage/` to prevent test artifacts from being committed

## Key Design Decisions

- **Stellar address validation**: Uses the same regex pattern (`^G[A-Z2-7]{55}$`) as the existing `verification.validator.ts` for consistency. This validates base32-encoded Stellar public keys.
- **Test architecture**: Follows the existing patterns in the repo — mocked repository layer for service tests, mocked service layer for route tests. Service tests use `jest.mock` to isolate `@neondatabase/serverless` and `permissions.repository`.
- **No production code restructuring**: The existing permissions system (service, repository, route, UI component) was already in place and functional. The changes here focus on validation hardening and test coverage.

## Acceptance Criteria Checklist

- [x] Granular permissions — Owners can assign view or edit rights per wallet address
- [x] Validation enforced — Only valid Stellar wallet addresses are accepted (regex: starts with G, 56 chars, base32 alphabet)
- [x] Secure management — Permission data is stored securely (SHA-256 on-chain hashes, activity logging) and linked to snippet ownership
- [x] Revocation supported — Owners can revoke or modify permissions seamlessly via DELETE endpoint
- [x] Transparent UI — PermissionsManager component shows permission type badges, wallet addresses, on-chain hashes, and activity history

## Test Output + Coverage

```
Test Suites: 2 passed, 2 total
Tests:       37 passed, 37 total

File                               | % Stmts | % Branch | % Funcs | % Lines
app/api/snippets/[id]/permissions/route.ts  |   100   |   100    |   100   |   100
lib/permissions.service.ts                 |   100   |   100    |   100   |   100
```

**Command to run tests:**
```bash
npm install --save-dev jest-environment-jsdom
npx jest --testPathPatterns="permissions" --coverage --env=node
```

## Honest Follow-ups

- The route tests require `--env=node` because the jsdom environment (set in `jest.config.mjs`) does not expose the global `Request` constructor used by Next.js. This is a pre-existing issue affecting all route tests in the repo (e.g., `app/api/reputation/route.test.ts` has the same failure).
- `jest-environment-jsdom` is listed in `jest.config.mjs` but was not installed — existing test files that rely on it also fail without manual install.
- The repository layer (`permissions.repository.ts`) uses live SQL queries via `@neondatabase/serverless` and is not unit-tested here. Integration tests against a test database would be a valuable addition.

## Security Note

Permission data is anchored with deterministic SHA-256 hashes (mimicking on-chain Stellar transaction hashes). In production, these would be replaced with real Stellar `manageData` operations for true immutability. The ownership guard ensures only the snippet owner can grant or revoke permissions. All mutations are recorded in an append-only activity log.