### PR TITLE
feat: implement decentralized snippet licensing

### DIFF
--- a/app/api/snippets/snippet.repository.ts
+++ b/app/api/snippets/snippet.repository.ts
@@ -162,19 +162,19 @@ export class SnippetRepository {
     return result[0] || null;
   }
 
-  async create(data: CreateSnippetDTO) {
+  async create(data: CreateSnippetDTO & { licenseTransactionHash?: string; licenseMetadata?: any }) {
     const id = crypto.randomUUID();
     const createdAt = new Date();
 
     const result = await this.sql`
-      INSERT INTO snippets (id, title, description, code, language, tags, owner_wallet_address, created_at, updated_at) 
-      VALUES (${id}, ${data.title}, ${data.description}, ${data.code}, ${data.language}, ${data.tags}, ${data.ownerWalletAddress}, ${createdAt}, ${createdAt}) 
+      INSERT INTO snippets (id, title, description, code, language, tags, owner_wallet_address, license_type, license_transaction_hash, license_metadata, created_at, updated_at) 
+      VALUES (${id}, ${data.title}, ${data.description}, ${data.code}, ${data.language}, ${data.tags}, ${data.ownerWalletAddress}, ${data.licenseType || null}, ${data.licenseTransactionHash || null}, ${data.licenseMetadata ? JSON.stringify(data.licenseMetadata) : null}, ${createdAt}, ${createdAt}) 
       RETURNING *
     `;
     return result[0];
   }
 
-  async update(id: string, data: UpdateSnippetDTO) {
+  async update(id: string, data: UpdateSnippetDTO & { licenseTransactionHash?: string; licenseMetadata?: any }) {
     const updatedAt = new Date();
 
     // Build dynamic update query using tagged template
@@ -202,7 +202,7 @@ export class SnippetRepository {
       values.push(data.tags);
     }
 
-    if (updates.length === 0) {
+    if (updates.length === 0 && !data.licenseType && !data.licenseTransactionHash) {
       return this.findById(id);
     }
 
@@ -217,6 +217,9 @@ export class SnippetRepository {
           code = COALESCE(${data.code}, code),
           language = COALESCE(${data.language}, language),
           tags = COALESCE(${data.tags}, tags),
+          license_type = COALESCE(${data.licenseType || null}, license_type),
+          license_transaction_hash = COALESCE(${data.licenseTransactionHash || null}, license_transaction_hash),
+          license_metadata = COALESCE(${data.licenseMetadata ? JSON.stringify(data.licenseMetadata) : null}, license_metadata),
           updated_at = ${updatedAt}
       WHERE id = ${id} AND is_deleted = false
       RETURNING *

--- a/app/api/snippets/snippet.service.ts
+++ b/app/api/snippets/snippet.service.ts
@@ -53,7 +53,30 @@ export class SnippetService {
 
     // 2. Database interaction via Repository
     try {
-      return await this.snippetRepository.create(validatedData);
+      // First create the snippet
+      let snippet = await this.snippetRepository.create(validatedData);
+
+      // If licenseType is provided, mint it and update the snippet
+      if (validatedData.licenseType && validatedData.licenseType !== "None") {
+        const { mintSnippetLicenseOnStellar } = await import("@/lib/stellar");
+        const tx = await mintSnippetLicenseOnStellar({
+          snippetId: snippet.id,
+          licenseType: validatedData.licenseType,
+          ownerWalletAddress: validatedData.ownerWalletAddress,
+        });
+
+        if (tx.success && tx.transactionHash) {
+          snippet = await this.snippetRepository.update(snippet.id, {
+            licenseTransactionHash: tx.transactionHash,
+            licenseMetadata: {
+              type: validatedData.licenseType,
+              timestamp: tx.timestamp,
+              memo: tx.memo,
+            }
+          } as any);
+        }
+      }
+      return snippet;
     } catch (error) {
       console.error("[Service] Error creating snippet:", error);
       throw new Error("Failed to create snippet");
@@ -64,10 +87,38 @@ export class SnippetService {
     const validatedData = updateSnippetSchema.parse(data);
 
     try {
-      const updated = await this.snippetRepository.update(id, validatedData);
-      if (!updated) {
+      const existing = await this.snippetRepository.findById(id);
+      if (!existing) {
         throw new Error("Snippet not found");
       }
+
+      let updated = await this.snippetRepository.update(id, validatedData);
+
+      // Mint license if it's being set for the first time
+      if (
+        validatedData.licenseType &&
+        validatedData.licenseType !== "None" &&
+        !existing.license_transaction_hash
+      ) {
+        const { mintSnippetLicenseOnStellar } = await import("@/lib/stellar");
+        const tx = await mintSnippetLicenseOnStellar({
+          snippetId: id,
+          licenseType: validatedData.licenseType,
+          ownerWalletAddress: existing.owner_wallet_address,
+        });
+
+        if (tx.success && tx.transactionHash) {
+          updated = await this.snippetRepository.update(id, {
+            licenseTransactionHash: tx.transactionHash,
+            licenseMetadata: {
+              type: validatedData.licenseType,
+              timestamp: tx.timestamp,
+              memo: tx.memo,
+            }
+          } as any);
+        }
+      }
+
       return updated;
     } catch (error) {
       if (error instanceof Error && error.message === "Snippet not found") {

--- a/app/api/snippets/snippet.validator.ts
+++ b/app/api/snippets/snippet.validator.ts
@@ -7,6 +7,7 @@ export const createSnippetSchema = z.object({
   language: z.string().min(1, "Language is required"),
   tags: z.array(z.string()).min(1, "At least one tag is required"),
   ownerWalletAddress: z.string().min(1, "Owner wallet address is required"),
+  licenseType: z.string().optional(),
 });
 
 export const updateSnippetSchema = z.object({
@@ -15,6 +16,7 @@ export const updateSnippetSchema = z.object({
   code: z.string().min(1, "Code is required").optional(),
   language: z.string().min(1, "Language is required").optional(),
   tags: z.array(z.string()).min(1, "At least one tag is required").optional(),
+  licenseType: z.string().optional(),
 });
 
 export type CreateSnippetDTO = z.infer<typeof createSnippetSchema>;

--- a/app/collections/page.tsx
+++ b/app/collections/page.tsx
@@ -31,6 +31,8 @@ interface Snippet {
   language: string;
   description: string;
   tags: string[];
+  license_type?: string;
+  license_transaction_hash?: string;
 }
 
 export default function CollectionsPage() {
@@ -337,10 +339,33 @@ export default function CollectionsPage() {
                           className="flex items-center justify-between gap-2 p-2.5 rounded-lg bg-slate-800 border border-slate-700"
                         >
                           <div className="min-w-0">
-                            <p className="text-sm font-medium text-slate-200 truncate">
-                              {snippet.title}
-                            </p>
-                            <p className="text-xs text-slate-500">{snippet.language}</p>
+                            <div className="flex items-center gap-2">
+                              <p className="text-sm font-medium text-slate-200 truncate">
+                                {snippet.title}
+                              </p>
+                              {snippet.license_type && (
+                                <span className="text-[10px] px-1.5 py-0.5 rounded border border-indigo-500/30 bg-indigo-500/10 text-indigo-300">
+                                  {snippet.license_type}
+                                </span>
+                              )}
+                            </div>
+                            <div className="flex items-center gap-2 text-xs text-slate-500">
+                              <span>{snippet.language}</span>
+                              {snippet.license_transaction_hash && (
+                                <>
+                                  <span>&middot;</span>
+                                  <a
+                                    href={`https://stellar.expert/explorer/testnet/tx/${snippet.license_transaction_hash}`}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="flex items-center gap-1 text-emerald-500/70 hover:text-emerald-400"
+                                    title="View License on Stellar"
+                                  >
+                                    <Globe className="w-3 h-3" /> Licensed on-chain
+                                  </a>
+                                </>
+                              )}
+                            </div>
                           </div>
                           <div className="flex items-center gap-1 shrink-0">
                             <Link href={`/snippets#${snippet.id}`}>

--- a/app/favorites/page.tsx
+++ b/app/favorites/page.tsx
@@ -23,6 +23,8 @@ interface Snippet {
   owner_wallet_address: string | null;
   created_at: string;
   updated_at: string;
+  license_type?: string;
+  license_transaction_hash?: string;
 }
 
 interface PaginatedResponse {
@@ -250,6 +252,24 @@ export default function FavoritesPage() {
                               />
                             )}
                           </div>
+                          {snippet.license_type && (
+                            <div className="flex items-center gap-2 text-xs">
+                              <span className="px-1.5 py-0.5 rounded border border-indigo-500/30 bg-indigo-500/10 text-indigo-300 font-medium">
+                                {snippet.license_type} License
+                              </span>
+                              {snippet.license_transaction_hash && (
+                                <a
+                                  href={`https://stellar.expert/explorer/testnet/tx/${snippet.license_transaction_hash}`}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="flex items-center gap-1 text-emerald-500/70 hover:text-emerald-400"
+                                  title="View License on Stellar"
+                                >
+                                  Licensed on-chain
+                                </a>
+                              )}
+                            </div>
+                          )}
                           <div className="flex flex-wrap items-center gap-2">
                             <span className="inline-block bg-purple-600/50 text-purple-100 text-xs px-3 py-1 rounded-full">
                               {snippet.language}

--- a/components/SnippetForm.tsx
+++ b/components/SnippetForm.tsx
@@ -63,6 +63,7 @@ export default function SnippetForm({
       code: initialValues?.code ?? "",
       language: initialValues?.language ?? "javascript",
       tags: initialValues?.tags ?? "",
+      licenseType: initialValues?.licenseType ?? "None",
     });
   }, [initialValues, reset]);
 
@@ -80,6 +81,7 @@ export default function SnippetForm({
               .map((t) => t.trim())
               .filter(Boolean)
           : [],
+        licenseType: data.licenseType === "None" ? undefined : data.licenseType,
       };
 
       const res = await fetch(
@@ -162,6 +164,28 @@ export default function SnippetForm({
                   {LANGUAGES.map((lang) => (
                     <SelectItem key={lang} value={lang}>
                       {lang.charAt(0).toUpperCase() + lang.slice(1)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <Label className="text-white">License</Label>
+          <Controller
+            name="licenseType"
+            control={control}
+            render={({ field }) => (
+              <Select value={field.value || "None"} onValueChange={field.onChange}>
+                <SelectTrigger className="bg-slate-700/50 border-purple-500/30 text-white">
+                  <SelectValue placeholder="Select a license" />
+                </SelectTrigger>
+                <SelectContent>
+                  {["None", "MIT", "Apache-2.0", "GPL-3.0", "BSD-3-Clause"].map((lic) => (
+                    <SelectItem key={lic} value={lic}>
+                      {lic}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/lib/stellar.ts
+++ b/lib/stellar.ts
@@ -362,3 +362,83 @@ function mockBatchStellarSubmit(
     memo: `batch:${batchHash.slice(0, 22)}`,
   };
 }
+
+/**
+ * Submit snippet license metadata to the Stellar blockchain.
+ */
+export async function mintSnippetLicenseOnStellar({
+  secretKey,
+  snippetId,
+  licenseType,
+  ownerWalletAddress,
+}: {
+  secretKey?: string;
+  snippetId: string;
+  licenseType: string;
+  ownerWalletAddress: string;
+}): Promise<StellarSubmitResult> {
+  const key = secretKey || STELLAR_SECRET_KEY;
+
+  if (!key) {
+    const timestamp = new Date().toISOString();
+    const memo = `lic:${snippetId.slice(0, 8)}`.slice(0, 28);
+    const txHash = crypto
+      .createHash("sha256")
+      .update(`${snippetId}:${licenseType}:${ownerWalletAddress}:${timestamp}`)
+      .digest("hex");
+
+    console.warn(
+      "[Stellar] License minting: no secret key configured — using deterministic mock.",
+    );
+
+    return {
+      success: true,
+      transactionHash: txHash,
+      timestamp,
+      memo,
+    };
+  }
+
+  try {
+    const server = new StellarSdk.Horizon.Server(HORIZON_URL);
+    const keypair = StellarSdk.Keypair.fromSecret(key);
+    const account = await server.loadAccount(keypair.publicKey());
+
+    const timestamp = new Date().toISOString();
+    const memoText = `lic:${snippetId.replace(/-/g, "").slice(0, 8)}`.slice(0, 28);
+
+    const transaction = new StellarSdk.TransactionBuilder(account, {
+      fee: StellarSdk.BASE_FEE,
+      networkPassphrase: NETWORK_PASSPHRASE,
+    })
+      .addOperation(
+        StellarSdk.Operation.manageData({
+          name: `lic:${snippetId.slice(0, 20)}`,
+          value: licenseType.slice(0, 64),
+        }),
+      )
+      .addMemo(StellarSdk.Memo.text(memoText))
+      .setTimeout(30)
+      .build();
+
+    transaction.sign(keypair);
+
+    const response = await server.submitTransaction(transaction);
+
+    return {
+      success: true,
+      transactionHash: response.hash,
+      ledger: response.ledger,
+      timestamp,
+      memo: memoText,
+    };
+  } catch (error: any) {
+    console.error("[Stellar] License minting failed:", error?.message);
+    const resultCodes = error?.response?.data?.extras?.result_codes;
+    const details = resultCodes ? JSON.stringify(resultCodes) : error?.message;
+    return {
+      success: false,
+      error: `Stellar license minting failed: ${details}`,
+    };
+  }
+}

--- a/scripts/add-licenses.sql
+++ b/scripts/add-licenses.sql
@@ -1,0 +1,8 @@
+-- Add license support to snippets table
+ALTER TABLE snippets 
+ADD COLUMN IF NOT EXISTS license_type VARCHAR(50),
+ADD COLUMN IF NOT EXISTS license_transaction_hash VARCHAR(255),
+ADD COLUMN IF NOT EXISTS license_metadata JSONB;
+
+-- Index on license_type for fast filtering
+CREATE INDEX IF NOT EXISTS idx_snippets_license_type ON snippets(license_type);

--- a/scripts/run-migrations.ts
+++ b/scripts/run-migrations.ts
@@ -50,6 +50,15 @@ async function runMigration() {
       console.log("✅ add-favorites.sql applied successfully");
     }
 
+    // 5. Run licenses table
+    const licensesPath = path.join(process.cwd(), "scripts", "add-licenses.sql");
+    if (fs.existsSync(licensesPath)) {
+      console.log("Applying add-licenses.sql...");
+      const licensesSql = fs.readFileSync(licensesPath, "utf-8");
+      await sql(licensesSql);
+      console.log("✅ add-licenses.sql applied successfully");
+    }
+
     console.log("Database initialized successfully!");
     process.exit(0);
   } catch (error) {

--- a/validiation/snippet-form-validiation.ts
+++ b/validiation/snippet-form-validiation.ts
@@ -16,6 +16,8 @@ export const snippetSchema = z.object({
   language: z.string().min(1, "Language is required"),
 
   tags: z.string().optional(),
+
+  licenseType: z.string().optional(),
 });
 
 export type SnippetFormValues = z.infer<typeof snippetSchema>;


### PR DESCRIPTION
Closes #134 

Allows creators to assign blockchain-backed licenses (MIT, Apache, GPL, etc.) to their snippets. Stores license metadata alongside ownership information for transparent usage rights and verifiable provenance.

**Key Changes:**
1. **License Assignment**: Added a dropdown to `SnippetForm.tsx` to enable snippet creators to select a license type (None, MIT, Apache-2.0, GPL-3.0, BSD-3-Clause) when publishing or updating snippets.
2. **Blockchain Storage**: Recorded license metadata on-chain alongside snippet owner information via `manageData` and `memo_text` using the Stellar SDK in `lib/stellar.ts`.
3. **Database Storage**: Migrated the `snippets` table to add `license_type`, `license_transaction_hash`, and `license_metadata` columns and updated `snippet.repository.ts` and API routes to handle and persist these properties.
4. **Transparent Display**: Updated both Collections and Favorites pages to display the license type directly on the snippet card, including an external link to the Stellar Explorer via the snippet's `license_transaction_hash` when available.